### PR TITLE
Update quickstart.rst

### DIFF
--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -21,6 +21,11 @@ Install new development platform
 
 .. code-block:: bash
 
+Does not work for Mac OS X 10.6.8; returns
+$ ./platformio install atmelavr
+Installing toolchain-atmelavr package:
+Error: The package 'toolchain-atmelavr' is not available for your system 'darwin_i386'
+
     $ platformio install PLATFORM
     Downloading  [####################################]  100%
     Unpacking  [####################################]  100%


### PR DESCRIPTION
Note will not work for 10.6.8. Perhaps include a note for all plaformio that command will not succeed. Perhaps an issue with Python. Not sure why darwin_i386 when should be something darwin_i686 or something 64-bit.
