### PR TITLE
Update platformio.ini

### DIFF
--- a/examples/atmelavr-native-blink/platformio.ini
+++ b/examples/atmelavr-native-blink/platformio.ini
@@ -3,12 +3,13 @@
 
 [env:arduino_pro5v]
 platform = atmelavr
-board_mcu = atmega168
-board_f_cpu = 16000000L
+board = nanoatmega168
+# board_mcu = atmega168
+# board_f_cpu = 16000000L
 
 upload_port = /dev/tty.SLAB_USBtoUART
 # upload_port = COM3
-upload_protocol = arduino
-upload_speed = 19200
+# upload_protocol = arduino
+# upload_speed = 19200
 
 targets = upload


### PR DESCRIPTION
To quote http://platformio.ikravets.com/#!/boards/arduino
"PlatformIO has pre-configured settings for most popular Embedded Boards.
You have no need to specify in Project Configuration File type or frequency of MCU, upload protocol or etc. Please use board option."

Specifies to use the "board" option, yet there is no board field in `platformio.ini`  Needs revision and possible omission of some fields with new board-option-syntax.  Possibly visit other affected files as well.
