### PR TITLE
Add inheritance in platformio.ini file via includes

### DIFF
--- a/platformio/exception.py
+++ b/platformio/exception.py
@@ -221,3 +221,12 @@ class CygwinEnvDetected(PlatformioException):
 
     MESSAGE = "PlatformIO does not work within Cygwin environment. "\
         "Use native Terminal instead."
+
+class UnknownIncludedSection(PlatformioException):
+
+    MESSAGE = "Unknown included section '{0}'"
+
+class RecursiveInclusion(PlatformioException):
+
+    MESSAGE = "Section '{0}' included recursively in '{1}'"
+

--- a/platformio/exception.py
+++ b/platformio/exception.py
@@ -222,11 +222,12 @@ class CygwinEnvDetected(PlatformioException):
     MESSAGE = "PlatformIO does not work within Cygwin environment. "\
         "Use native Terminal instead."
 
+
 class UnknownIncludedSection(PlatformioException):
 
     MESSAGE = "Unknown included section '{0}'"
 
+
 class RecursiveInclusion(PlatformioException):
 
     MESSAGE = "Section '{0}' included recursively in '{1}'"
-

--- a/platformio/util.py
+++ b/platformio/util.py
@@ -53,27 +53,28 @@ class ProjectConfig(ConfigParser):
 
     def items(self, section, **kwargs):
         items = {}
+
         try:
-            for option in ConfigParser.options(self, section):
-                if option == 'include':
-
-                    try:
-                        kwargs['previous'].append(section)
-                    except:
-                        kwargs['previous'] = [section]
-
-                    includes = self.get(section, 'include').split(',')
-                    for include in includes:
-                        if include in kwargs['previous']:
-                            raise exception.RecursiveInclusion(include, section)
-                        override = dict(self.items(include.strip(' '), **kwargs))
-                        items = self.merge(items, override)
-
-                else:
-                    items[option] = self.get(section, option)
-
+            options = ConfigParser.options(self, section);
         except NoSectionError:
             raise exception.UnknownIncludedSection(section)
+
+        for option in options:
+            if option == 'include':
+                try:
+                    kwargs['previous'].append(section)
+                except:
+                    kwargs['previous'] = [section]
+
+                includes = self.get(section, 'include').split(',')
+                for include in includes:
+                    if include in kwargs['previous']:
+                        raise exception.RecursiveInclusion(include, section)
+                    override = self.items(include.strip(' '), **kwargs)
+                    items = self.merge(items, dict(override))
+
+            else:
+                items[option] = self.get(section, option)
 
         return items.items()
 

--- a/platformio/util.py
+++ b/platformio/util.py
@@ -88,7 +88,7 @@ class ProjectConfig(ConfigParser):
                 try:
                     return self.get(include.strip(' '), option)
                 except NoSectionError:
-                    raise UnknownIncludedSection(section)
+                    raise exception.UnknownIncludedSection(section)
                 except NoOptionError:
                     None
             raise NoOptionError(option, section)

--- a/platformio/util.py
+++ b/platformio/util.py
@@ -55,7 +55,7 @@ class ProjectConfig(ConfigParser):
         items = {}
 
         try:
-            options = ConfigParser.options(self, section);
+            options = ConfigParser.options(self, section)
         except NoSectionError:
             raise exception.UnknownIncludedSection(section)
 


### PR DESCRIPTION
The new dynamic variables feature in the platformio.ini file is cool but I think it's more flexible a inheritance approach like this one.

An "include" option is processed and expanded with all the options from the included section. It allows:
- Multiple inheritance (you can include more than one section in the same "include" option, comma-separated)
- Multilevel inheritance (a section can inherit from another section that inherits from a third one an so on)
- Recursion check (a section cannot inherit from another one that inherits from the first one)

An example of a platformio.ini file using this modification is:

```
[platformio]
env_default = test

[common]
platform = espressif8266
framework = arduino
lib_install = 19,64,89,408,549
build_flags = -DDEBUG_PORT=Serial
extra_script = pio_hooks.py

[ota]
upload_speed = 115200
upload_port = "mydevice.local"
upload_flags = --auth=mydevicepass --port 8266

[env:test]
include = common
board = nodemcuv2

[env:test-ota]
include = env:test,ota

[env:mydevice]
include = common
board = esp12e

[env:mydevice-ota]
include = env:mydevice,ota
```
