### PR TITLE
Allow git ssh user to be included with lib_deps url

### DIFF
--- a/platformio/managers/package.py
+++ b/platformio/managers/package.py
@@ -297,12 +297,13 @@ class BasePkgManager(PkgRepoMixin, PkgInstallerMixin):
     def parse_pkg_name(  # pylint: disable=too-many-branches
             text, requirements=None):
         text = str(text)
-        if not requirements and "@" in text and not text.startswith("git@"):
+        url_marker = "://"
+        if not requirements and "@" in text and not url_marker + "git@" in text:
+        # if not requirements and "@" in text and not text.startswith("git@"):
             text, requirements = text.rsplit("@", 1)
         if text.isdigit():
             text = "id=" + text
 
-        url_marker = "://"
         name, url = (None, text)
         if "=" in text and not text.startswith("id="):
             name, url = text.split("=", 1)

--- a/platformio/managers/package.py
+++ b/platformio/managers/package.py
@@ -302,7 +302,7 @@ class BasePkgManager(PkgRepoMixin, PkgInstallerMixin):
         url_conditions = [
             not requirements,
             "@" in text,
-            not "git@" in text,
+            not text.startswith("git@"),
             not url_marker + "git@" in text
         ]
 

--- a/platformio/managers/package.py
+++ b/platformio/managers/package.py
@@ -298,8 +298,15 @@ class BasePkgManager(PkgRepoMixin, PkgInstallerMixin):
             text, requirements=None):
         text = str(text)
         url_marker = "://"
-        if not requirements and "@" in text and not url_marker + "git@" in text:
-        # if not requirements and "@" in text and not text.startswith("git@"):
+
+        url_conditions = [
+            not requirements,
+            "@" in text,
+            not "git@" in text,
+            not url_marker + "git@" in text
+        ]
+
+        if all(url_conditions):
             text, requirements = text.rsplit("@", 1)
         if text.isdigit():
             text = "id=" + text


### PR DESCRIPTION
A patch to fix issue #830 

This patch takes the existing conditionals, which check for an '@' character indicating a required version of the given dependency, and adds an additional check for the 'git' username when used in conjunction with a protocol like git+ssh. 

This fixes the current behavior where a URL in the form of 
```
git+ssh://git@my-private-repo.com/some-user/some-project.git
```
 would be parsed as a dependency having a required version of `my-private-repo.com/some-user/some-project.git` which causes an exception during installation.

I have also reorganized the conditionals into a list for readability.