### PR TITLE
Feature/sort serialports

### DIFF
--- a/platformio/util.py
+++ b/platformio/util.py
@@ -378,6 +378,11 @@ def get_serialports(filter_hwid=False):
 
     if filter_hwid:
         return result
+        
+    if system() == "Windows":
+        result = sorted(result, key=lambda x:int(x["port"][3:]) )
+    else:
+        result = sorted(result, key=lambda x:x["port"])
 
     # fix for PySerial
     if not result and platform.system() == "Darwin":

--- a/platformio/util.py
+++ b/platformio/util.py
@@ -378,11 +378,11 @@ def get_serialports(filter_hwid=False):
 
     if filter_hwid:
         return result
-        
-    if system() == "Windows":
-        result = sorted(result, key=lambda x:int(x["port"][3:]) )
+
+    if platform.system() == "Windows":
+        result = sorted(result, key=lambda x: int(x["port"][3:]))
     else:
-        result = sorted(result, key=lambda x:x["port"])
+        result = sorted(result, key=lambda x: x["port"])
 
     # fix for PySerial
     if not result and platform.system() == "Darwin":


### PR DESCRIPTION
Simply sort the list of serial ports from util.get_serialports

**Reason:**
When no HwId is given in the board configuration the autodetect function will simply use the last port returned from get_serialports()
At least on windows, the returned list is not guranteed to be in any specific order.
To make uploading more predictable, I suggest sorting the ports to have a strict ascending order.

**Background:**
On my PC I have a constantly connected Arduino Leonardo (COM1) and e.g. a ESP8266 board (COM6).
When using autodetect, it often returns the list [COM6, COM1] and tries to upload on COM1.
Even when setting the Leonardo to COM265 it still returns [COM6, COM265].
My change allows to set constantly attached boards to low COM-Ports which will not be selected by autodetect when a higher-number COM port is available.

Sorry for the not-yet-signed CLA, CLAHub is throwing me errors when trying to sign it