### PR TITLE
Added support for templated methods in InoToCPPConverter

### DIFF
--- a/platformio/builder/tools/piomisc.py
+++ b/platformio/builder/tools/piomisc.py
@@ -31,6 +31,7 @@ from platformio import util
 class InoToCPPConverter(object):
 
     PROTOTYPE_RE = re.compile(r"""^(
+        (?:template\<.*\>\s*)?      # template
         ([a-z_\d]+\*?\s+){1,2}      # return type
         ([a-z_\d]+\s*)              # name of prototype
         \([a-z_,\.\*\&\[\]\s\d]*\)  # arguments

--- a/tests/ino2cpp/basic/basic.ino
+++ b/tests/ino2cpp/basic/basic.ino
@@ -26,11 +26,14 @@ Foo foo(&fooCallback);
 
 //
 
+template<class T> T Add(T n1, T n2) {
+    return n1 + n2;
+}
+
 void setup() {
     struct Item item1;
     myFunction(&item1);
 }
-
 
 void loop() {
 
@@ -40,7 +43,7 @@ void myFunction(struct Item *item) {
 
 }
 
-#warning "Line number is 43"
+#warning "Line number is 46"
 
 void fooCallback(){
 

--- a/tests/test_ino2cpp.py
+++ b/tests/test_ino2cpp.py
@@ -42,7 +42,7 @@ def test_warning_line(clirunner, validate_cliresult):
     validate_cliresult(result)
     assert ('basic.ino:16:14: warning: #warning "Line number is 16"' in
             result.output)
-    assert ('basic.ino:43:2: warning: #warning "Line number is 43"' in
+    assert ('basic.ino:46:2: warning: #warning "Line number is 46"' in
             result.output)
     result = clirunner.invoke(
         cmd_ci, [join(INOTEST_DIR, "strmultilines"), "-b", "uno"])


### PR DESCRIPTION
The InoToCPPConverter class does not match templated methods, like for instance this one:
```
template<typename T> bool setSetting(const String& key, T value) {
    return Embedis::set(key, String(value));
}
```