### PR TITLE
set CMAKE_CXX_STANDARD for CLion syntax help

### DIFF
--- a/platformio/ide/tpls/clion/CMakeLists.txt.tpl
+++ b/platformio/ide/tpls/clion/CMakeLists.txt.tpl
@@ -1,6 +1,8 @@
 cmake_minimum_required(VERSION 3.2)
 project({{project_name}})
 
+set(CMAKE_CXX_STANDARD 14)
+
 include(CMakeListsPrivate.txt)
 
 add_custom_target(


### PR DESCRIPTION
Without this set, CLion complains about many c++ features like std::unordered_map, lambdas, auto, etc.