### PR TITLE
Escape spaces in task command for VSCode Task Runner

### DIFF
--- a/platformio/ide/tpls/vscode/.vscode/tasks.json.tpl
+++ b/platformio/ide/tpls/vscode/.vscode/tasks.json.tpl
@@ -1,7 +1,7 @@
 {
     "version": "0.1.0",
     "runner": "terminal",
-    "command": "\"{{platformio_path}}\"",
+    "command": "&'{{platformio_path}}'",
     "isShellCommand": false,
     "args": ["-c", "vscode"],
     "showOutput": "always",


### PR DESCRIPTION
Refering to https://community.platformio.org/t/space-in-path-causes-error/2127 and just escaping the " character doesn't work, I think this solves the problem.