### PR TITLE
Avoid Dwengo board not being detected after force reset

### DIFF
--- a/platformio/builder/tools/pioupload.py
+++ b/platformio/builder/tools/pioupload.py
@@ -48,7 +48,7 @@ def TouchSerialPort(env, port, baudrate):
         s.close()
     except:  # pylint: disable=W0702
         pass
-    sleep(0.4)  # DO NOT REMOVE THAT (required by SAM-BA based boards)
+    sleep(5.0)  # DO NOT REMOVE THAT (required by SAM-BA based boards)
 
 
 def WaitForNewSerialPort(env, before):


### PR DESCRIPTION
Uploading to my Dwengo board always fails: the board is not found.

Increasing the delay after the reset command fixes this.
