### PR TITLE
Additional fix to 7354515

### DIFF
--- a/platformio/ide/tpls/clion/CMakeListsPrivate.txt.tpl
+++ b/platformio/ide/tpls/clion/CMakeListsPrivate.txt.tpl
@@ -8,7 +8,7 @@ SET(CMAKE_C_FLAGS_DISTRIBUTION "{{cc_flags}}")
 set(CMAKE_CXX_STANDARD 11)
 
 % for define in defines:
-add_definitions(-D'{{!re.sub(r"([()#])",r"\\\1",define)}}')
+add_definitions(-D'{{!re.sub(r"([\"()#])",r"\\\1",define)}}')
 % end
 
 % for include in includes:

--- a/platformio/ide/tpls/clion/CMakeListsPrivate.txt.tpl
+++ b/platformio/ide/tpls/clion/CMakeListsPrivate.txt.tpl
@@ -8,9 +8,7 @@ SET(CMAKE_C_FLAGS_DISTRIBUTION "{{cc_flags}}")
 set(CMAKE_CXX_STANDARD 11)
 
 % for define in defines:
-% if "##" not in define:
-add_definitions("-D{{!define.replace("(", "\(").replace(")", "\)").replace('"', '\\"')}}")
-% end
+add_definitions(-D'{{!re.sub(r"([()#])",r"\\\1",define)}}')
 % end
 
 % for include in includes:


### PR DESCRIPTION
The same fix as in commit 7354515 by @ivankravets, plus:
* correct handling of macro-functions with concatenation (`##`) operation
* correct behaviour for spaces in macros. Without quotes around `-D` option's argument I experienced errors like:
  ```
  Problems were encountered while collecting compiler information:
  	xtensa-lx106-elf-g++: error: long: No such file or directory
  	xtensa-lx106-elf-g++: error: unsigned: No such file or directory
  	xtensa-lx106-elf-g++: error: int: No such file or directory
  ```
  for defines like `add_definitions(-D__UINT_LEAST64_TYPE__=long long unsigned int)`
  "idea" of `-D...` -> `-D'...'` taken form [here](https://gcc.gnu.org/onlinedocs/cpp/Invocation.html).

This patch:
* Tested on CLion 2017.2.3: IDE imports project without warnings or errors
* Verified correct macro expansion by IDE for macros with hashes (i.e. `__UINT32_C(12)` expands to `12UL`)


  