### PR TITLE
Fix CLion not recognizing includes in lib and .piolibdeps

### DIFF
--- a/platformio/ide/projectgenerator.py
+++ b/platformio/ide/projectgenerator.py
@@ -158,6 +158,7 @@ class ProjectGenerator(object):
                 "project_dir": self.project_dir,
                 "project_src_dir": util.get_projectsrc_dir(),
                 "project_lib_dir": util.get_projectlib_dir(),
+                "project_libdeps_dir": util.get_projectlibdeps_dir(),
                 "systype": util.get_systype(),
                 "platformio_path": self._fix_os_path(
                     util.where_is_program("platformio")),

--- a/platformio/ide/tpls/clion/CMakeListsPrivate.txt.tpl
+++ b/platformio/ide/tpls/clion/CMakeListsPrivate.txt.tpl
@@ -24,4 +24,4 @@ include_directories("{{include.replace("\\", "/")}}")
 % end
 % end
 
-FILE(GLOB_RECURSE SRC_LIST "{{project_src_dir.replace("\\", "/")}}/*.*")
+FILE(GLOB_RECURSE SRC_LIST "{{project_src_dir.replace("\\", "/")}}/*.*" "{{project_lib_dir.replace("\\", "/")}}/*.*" "{{project_libdeps_dir.replace("\\", "/")}}/*.*")


### PR DESCRIPTION
This PR fixes the problem discussed in [this post](https://community.platformio.org/t/clion-fails-to-find-include-files-in-lib-folder/3247) by adding source files from `lib` and `.piolibdeps` to `SRC_LIST`.