### PR TITLE
shutil.move() instead of os.rename()

### DIFF
--- a/platformio/managers/package.py
+++ b/platformio/managers/package.py
@@ -502,7 +502,7 @@ class PkgInstallerMixin(object):
                     target_dirname = "%s@src-%s" % (
                         pkg_dirname,
                         hashlib.md5(cur_manifest['__src_url']).hexdigest())
-                os.rename(pkg_dir, join(self.package_dir, target_dirname))
+                shutil.move(pkg_dir, join(self.package_dir, target_dirname))
             # fix to a version
             elif action == 2:
                 target_dirname = "%s@%s" % (pkg_dirname,
@@ -516,7 +516,7 @@ class PkgInstallerMixin(object):
         # remove previous/not-satisfied package
         if isdir(pkg_dir):
             util.rmtree_(pkg_dir)
-        os.rename(tmp_dir, pkg_dir)
+        shutil.move(tmp_dir, pkg_dir)
         assert isdir(pkg_dir)
         self.cache_reset()
         return pkg_dir
@@ -740,7 +740,7 @@ class BasePkgManager(PkgRepoMixin, PkgInstallerMixin):
         # unfix package with the same name
         pkg_dir = self.get_package_dir(manifest['name'])
         if pkg_dir and "@" in pkg_dir:
-            os.rename(pkg_dir,
+            shutil.move(pkg_dir,
                       join(self.package_dir,
                            self.get_install_dirname(manifest)))
             self.cache_reset()


### PR DESCRIPTION
os.rename only works if src and dst are on the same filesystem, and will fail otherwise.
shutil.move() handles these cases better:
https://www.pythoncentral.io/how-to-rename-move-a-file-in-python/