### PR TITLE
Solved issues with vim whitespaces in paths

### DIFF
--- a/platformio/ide/tpls/vim/.clang_complete.tpl
+++ b/platformio/ide/tpls/vim/.clang_complete.tpl
@@ -1,5 +1,5 @@
 % for include in includes:
--I{{include}}
+-I"{{include}}"
 % end
 % for define in defines:
 -D{{!define}}

--- a/platformio/ide/tpls/vim/.gcc-flags.json.tpl
+++ b/platformio/ide/tpls/vim/.gcc-flags.json.tpl
@@ -3,6 +3,6 @@
   "gccDefaultCFlags": "-fsyntax-only {{! cc_flags.replace(' -MMD ', ' ').replace('"', '\\"') }}",
   "gccDefaultCppFlags": "-fsyntax-only {{! cxx_flags.replace(' -MMD ', ' ').replace('"', '\\"') }}",
   "gccErrorLimit": 15,
-  "gccIncludePaths": "{{ ','.join(includes).replace("\\", "/") }}",
+  "gccIncludePaths": "{{! ','.join("'{}'".format(w.replace("\\", '/')) for w in includes)}}",
   "gccSuppressWarnings": false
 }


### PR DESCRIPTION
When a library has whitespaces in the name the path
will contain whitespace too. When vim tries to decode
path it will fail.

This fix wrap each path with quotes.