### PR TITLE
Surround ld script path in quotation marks

### DIFF
--- a/platformio/builder/tools/platformio.py
+++ b/platformio/builder/tools/platformio.py
@@ -121,7 +121,7 @@ def BuildProgram(env):
     # append into the beginning a main LD script
     if (env.get("LDSCRIPT_PATH")
             and not any("-Wl,-T" in f for f in env['LINKFLAGS'])):
-        env.Prepend(LINKFLAGS=["-T", "$LDSCRIPT_PATH"])
+        env.Prepend(LINKFLAGS=["-T", "\"$LDSCRIPT_PATH\""])
 
     # enable "cyclic reference" for linker
     if env.get("LIBS") and env.GetCompilerType() == "gcc":


### PR DESCRIPTION
While following [this tutorial](https://docs.platformio.org/en/latest/tutorials/ststm32/stm32cube_debugging_unit_testing.html#tutorial-stm32cube-debugging-unit-testing) I got a `No such file or directory` error during the build. After building with the verbose tag I saw that the path was not surrounded in quotation marks. This resulted in gcc not finding the file as the path contained a space.

After locally adding the marks in the script the build succeeded. I don't think it is the responsibility for the platforms to provide the `LDSCRIPT_PATH` environment variable already enclosed is it?