### PR TITLE
Ignore vscode-cpptools cache

### DIFF
--- a/platformio/ide/tpls/vscode/.gitignore.tpl
+++ b/platformio/ide/tpls/vscode/.gitignore.tpl
@@ -2,3 +2,4 @@
 .vscode/.browse.c_cpp.db*
 .vscode/c_cpp_properties.json
 .vscode/launch.json
+.vscode/ipch


### PR DESCRIPTION
One of the recent updates to the vscode-cpptools extension made it start caching in .vscode/ipch, and this cache can be quite big for even small projects. Since they're cache files, they should be ignored by default. This may be a short-lived suggestion, as there is already some mention that the IntelliSense cache folder may be moved to workspace storage, rather than 'per project' storage... although the 'when' is anyone's guess. 

See here for more: https://github.com/microsoft/vscode-cpptools/issues/3347