### PR TITLE
Missing parentheses and depreciated syntax

### DIFF
--- a/scripts/get-platformio.py
+++ b/scripts/get-platformio.py
@@ -90,7 +90,7 @@ def exec_python_cmd(args):
 def install_pip():
     r = exec_python_cmd(["-m", "pip", "--version"])
     if r['returncode'] == 0:
-        print r['out']
+        print(r['out'])
         return
     try:
         from urllib2 import urlopen
@@ -143,7 +143,7 @@ def main():
         try:
             s[1]()
             print("[SUCCESS]")
-        except Exception, e:
+        except Exception as e:
             is_error = True
             print(str(e))
             print("[FAILURE]")


### PR DESCRIPTION
Shouldn't have been able to break this the way I did... but I did (by-product of trying to coerce an embedded python install to work with platformio on windows). python3 hurdles. 

```
  File "get-platformio.py", line 93
    print r['out']
          ^
SyntaxError: Missing parentheses in call to 'print'. Did you mean print(r['out'])?
```

and 

```
  File "get-platformio.py", line 146
    except Exception, e:
                    ^
SyntaxError: invalid syntax
```