### PR TITLE
Fix for tpls/eclipse/.cproject.tpl

### DIFF
--- a/platformio/ide/tpls/eclipse/.cproject.tpl
+++ b/platformio/ide/tpls/eclipse/.cproject.tpl
@@ -221,7 +221,7 @@
 				<buildArguments>-f -c eclipse</buildArguments>
 				<buildTarget>run -t program</buildTarget>
 				<stopOnError>true</stopOnError>
-				<useDefaultCommand>true</useDefaultCommand>
+				<useDefaultCommand>false</useDefaultCommand>
 				<runAllBuilders>false</runAllBuilders>
 			</target>
 			<target name="PlatformIO: Upload SPIFFS image" path="" targetID="org.eclipse.cdt.build.MakeTargetBuilder">
@@ -229,7 +229,7 @@
 				<buildArguments>-f -c eclipse</buildArguments>
 				<buildTarget>run -t uploadfs</buildTarget>
 				<stopOnError>true</stopOnError>
-				<useDefaultCommand>true</useDefaultCommand>
+				<useDefaultCommand>false</useDefaultCommand>
 				<runAllBuilders>false</runAllBuilders>
 			</target>
 			<target name="PlatformIO: Build" path="" targetID="org.eclipse.cdt.build.MakeTargetBuilder">
@@ -237,7 +237,7 @@
 				<buildArguments>-f -c eclipse</buildArguments>
 				<buildTarget>run</buildTarget>
 				<stopOnError>true</stopOnError>
-				<useDefaultCommand>true</useDefaultCommand>
+				<useDefaultCommand>false</useDefaultCommand>
 				<runAllBuilders>false</runAllBuilders>
 			</target>
 			<target name="PlatformIO: Upload" path="" targetID="org.eclipse.cdt.build.MakeTargetBuilder">
@@ -245,7 +245,7 @@
 				<buildArguments>-f -c eclipse</buildArguments>
 				<buildTarget>run -t upload</buildTarget>
 				<stopOnError>true</stopOnError>
-				<useDefaultCommand>true</useDefaultCommand>
+				<useDefaultCommand>false</useDefaultCommand>
 				<runAllBuilders>false</runAllBuilders>
 			</target>
 			<target name="PlatformIO: Clean" path="" targetID="org.eclipse.cdt.build.MakeTargetBuilder">
@@ -253,7 +253,7 @@
 				<buildArguments>-f -c eclipse</buildArguments>
 				<buildTarget>run -t clean</buildTarget>
 				<stopOnError>true</stopOnError>
-				<useDefaultCommand>true</useDefaultCommand>
+				<useDefaultCommand>false</useDefaultCommand>
 				<runAllBuilders>false</runAllBuilders>
 			</target>
 			<target name="PlatformIO: Test" path="" targetID="org.eclipse.cdt.build.MakeTargetBuilder">
@@ -261,7 +261,7 @@
 				<buildArguments>-f -c eclipse</buildArguments>
 				<buildTarget>test</buildTarget>
 				<stopOnError>true</stopOnError>
-				<useDefaultCommand>true</useDefaultCommand>
+				<useDefaultCommand>false</useDefaultCommand>
 				<runAllBuilders>false</runAllBuilders>
 			</target>
 			<target name="PlatformIO: Update platforms and libraries" path="" targetID="org.eclipse.cdt.build.MakeTargetBuilder">
@@ -269,7 +269,7 @@
 				<buildArguments>-f -c eclipse</buildArguments>
 				<buildTarget>update</buildTarget>
 				<stopOnError>true</stopOnError>
-				<useDefaultCommand>true</useDefaultCommand>
+				<useDefaultCommand>false</useDefaultCommand>
 				<runAllBuilders>false</runAllBuilders>
 			</target>
 			<target name="PlatformIO: Rebuild C/C++ Project Index" path="" targetID="org.eclipse.cdt.build.MakeTargetBuilder">
@@ -277,7 +277,7 @@
 				<buildArguments>-f -c eclipse</buildArguments>
 				<buildTarget>init --ide eclipse</buildTarget>
 				<stopOnError>true</stopOnError>
-				<useDefaultCommand>true</useDefaultCommand>
+				<useDefaultCommand>false</useDefaultCommand>
 				<runAllBuilders>false</runAllBuilders>
 			</target>
 		</buildTargets>


### PR DESCRIPTION
In the current version of this template, all build targets result in a command line

   pio -c -f eclipse debug run target <mytarget>

The commit fixes this to be

   pio -c -f eclipse run target <mytarget>

See also discussion in forum:
   https://community.platformio.org/t/pio-4-0-0b3-potential-bug-in-cprojet-tpl/8390