### PR TITLE
Make scripts compatible with py2 and py3

### DIFF
--- a/scripts/docspregen.py
+++ b/scripts/docspregen.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from __future__ import print_function
 
 import os
 import urlparse
@@ -280,7 +281,7 @@ Packages
 
 
 def generate_platform(name, rst_dir):
-    print "Processing platform: %s" % name
+    print("Processing platform: %s" % name)
 
     compatible_boards = [
         board for board in BOARDS if name == board['platform']
@@ -439,7 +440,7 @@ def update_platform_docs():
 
 
 def generate_framework(type_, data, rst_dir=None):
-    print "Processing framework: %s" % type_
+    print("Processing framework: %s" % type_)
 
     compatible_platforms = [
         m for m in PLATFORM_MANIFESTS

--- a/scripts/fixsymlink.py
+++ b/scripts/fixsymlink.py
@@ -12,13 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import print_function
+
 from os import chdir, getcwd, readlink, remove, symlink, walk
 from os.path import exists, islink, join, relpath
 from sys import exit as sys_exit
 
 
 def fix_symlink(root, fname, brokenlink):
-    print root, fname, brokenlink
+    print(root, fname, brokenlink)
     prevcwd = getcwd()
 
     chdir(root)


### PR DESCRIPTION
Not all scripte are compatible with py3 in 4.0.0 release
Signed-off-by: Alexey Shvetsov <alexxy@gentoo.org>