### PR TITLE
Clean-up error handling in 'run' command

### DIFF
--- a/platformio/commands/run/command.py
+++ b/platformio/commands/run/command.py
@@ -23,6 +23,7 @@ from platformio import exception, fs
 from platformio.commands.device import device_monitor as cmd_device_monitor
 from platformio.commands.run.helpers import (clean_build_dir,
                                              handle_legacy_libdeps,
+                                             handle_legacy_build_dir,
                                              print_summary)
 from platformio.commands.run.processor import EnvironmentProcessor
 from platformio.project.config import ProjectConfig
@@ -78,17 +79,13 @@ def cli(ctx, environment, target, upload_port, project_dir, project_conf, jobs,
             project_conf or join(project_dir, "platformio.ini"))
         config.validate(environment)
 
+        build_dir = get_project_build_dir()
+
         # clean obsolete build dir
         if not disable_auto_clean:
-            try:
-                clean_build_dir(get_project_build_dir(), config)
-            except:  # pylint: disable=bare-except
-                click.secho(
-                    "Can not remove temporary directory `%s`. Please remove "
-                    "it manually to avoid build issues" %
-                    get_project_build_dir(force=True),
-                    fg="yellow")
+            clean_build_dir(build_dir, config)
 
+        handle_legacy_build_dir(project_dir, build_dir)
         handle_legacy_libdeps(project_dir, config)
 
         results = []

--- a/platformio/commands/run/helpers.py
+++ b/platformio/commands/run/helpers.py
@@ -20,7 +20,6 @@ import click
 
 from platformio import fs
 from platformio.project.helpers import (compute_project_checksum,
-                                        get_project_dir,
                                         get_project_libdeps_dir)
 
 

--- a/platformio/commands/run/helpers.py
+++ b/platformio/commands/run/helpers.py
@@ -43,12 +43,14 @@ def handle_legacy_libdeps(project_dir, config):
         fg="yellow")
 
 
-def clean_build_dir(build_dir, config):
+def handle_legacy_build_dir(project_dir, build_dir):
     # remove legacy ".pioenvs" folder
-    legacy_build_dir = join(get_project_dir(), ".pioenvs")
+    legacy_build_dir = join(project_dir, ".pioenvs")
     if isdir(legacy_build_dir) and legacy_build_dir != build_dir:
         fs.rmtree(legacy_build_dir)
 
+
+def clean_build_dir(build_dir, config):
     checksum_file = join(build_dir, "project.checksum")
     checksum = compute_project_checksum(config)
 

--- a/platformio/fs.py
+++ b/platformio/fs.py
@@ -153,7 +153,7 @@ def rmtree(path):
         try:
             os.chmod(name, stat.S_IWRITE)
             os.remove(name)
-        except:  # pylint: disable=broad-except
+        except:  # pylint: disable=bare-except
             click.secho("%s \nPlease manually remove `%s` to avoid build issues" %
                         (str(top_exc), name),
                         fg="red",

--- a/platformio/fs.py
+++ b/platformio/fs.py
@@ -148,13 +148,14 @@ def match_src_files(src_dir, src_filter=None, src_exts=None):
 
 def rmtree(path):
 
-    def _onerror(_, name, __):
+    def _onerror(_, name, exc_info):
+        _, top_exc, _ = exc_info
         try:
             os.chmod(name, stat.S_IWRITE)
             os.remove(name)
-        except Exception as e:  # pylint: disable=broad-except
-            click.secho("%s \nPlease manually remove the file `%s`" %
-                        (str(e), name),
+        except:  # pylint: disable=broad-except
+            click.secho("%s \nPlease manually remove `%s` to avoid build issues" %
+                        (str(top_exc), name),
                         fg="red",
                         err=True)
 

--- a/platformio/project/helpers.py
+++ b/platformio/project/helpers.py
@@ -167,7 +167,7 @@ def get_project_shared_dir():
 
 def compute_project_checksum(config):
     # rebuild when PIO Core version changes
-    checksum = sha1(__version__)
+    checksum = sha1(hashlib_encode_data(__version__))
 
     # configuration file state
     checksum.update(hashlib_encode_data(config.to_json()))


### PR DESCRIPTION
- create `handle_legacy_build_dir()` and move '.pioenvs' clean-up code there
- make sha1() py3-compatible. otherwise, it will trigger bogus warning about the need to manually remove build directory. the real exception is:
```python
  File "/home/builder/git/platformio-core/platformio/project/helpers.py", line 170, in compute_project_checksum
    checksum = sha1(__version__)
TypeError: Unicode-objects must be encoded before hashing
```
- show original exception via fs.rmtree onerror handler
for example:
```python
[Errno 13] Permission denied: '/home/builder/project/.pioenvs'
Please manually remove `/home/builder/project/.pioenvs` to avoid build issues
```
instead of
```python
[Errno 21] Is a directory: '/home/builder/project/.pioenvs'
Please manually remove the file `/home/builder/project/.pioenvs`
```
which is not useful at all