### PR TITLE
Clion integration, resolves #2824

### DIFF
--- a/platformio/ide/tpls/clion/.idea/workspace.xml.tpl
+++ b/platformio/ide/tpls/clion/.idea/workspace.xml.tpl
@@ -15,10 +15,18 @@
       <config projectName="{{project_name}}" targetName="DEBUG" />
     </generated>
   </component>
-  <component name="CMakeSettings" AUTO_RELOAD="true" GENERATION_PASS_SYSTEM_ENVIRONMENT="true">
-    <ADDITIONAL_GENERATION_ENVIRONMENT>
-      <envs />
-    </ADDITIONAL_GENERATION_ENVIRONMENT>
+  <component name="CMakeSettings" AUTO_RELOAD="true">
+   <configurations>
+%   envs = config.envs()
+%   if len(envs) > 1:
+%       for env in envs:
+      <configuration PROFILE_NAME="{{ env }}" CONFIG_NAME="{{ env }}" />
+%       end
+      <configuration PROFILE_NAME="All" CONFIG_NAME="All" />
+%   else:
+      <configuration PROFILE_NAME="{{ env_name }}" CONFIG_NAME="{{ env_name }}" />
+%   end
+    </configurations>
   </component>
   <component name="ChangeListManager">
     <list default="true" id="ec922180-b3d3-40f1-af0b-2568113a9075" name="Default" comment="" />

--- a/platformio/ide/tpls/clion/CMakeLists.txt.tpl
+++ b/platformio/ide/tpls/clion/CMakeLists.txt.tpl
@@ -16,49 +16,49 @@ endif()
 
 add_custom_target(
     PLATFORMIO_BUILD ALL
-    COMMAND ${PLATFORMIO_CMD} -f -c clion run
+    COMMAND ${PLATFORMIO_CMD} -f -c clion run "$<$<NOT:$<CONFIG:All>>:-e${CMAKE_BUILD_TYPE}>"
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
 )
 
 add_custom_target(
     PLATFORMIO_BUILD_VERBOSE ALL
-    COMMAND ${PLATFORMIO_CMD} -f -c clion run --verbose
+    COMMAND ${PLATFORMIO_CMD} -f -c clion run --verbose "$<$<NOT:$<CONFIG:All>>:-e${CMAKE_BUILD_TYPE}>"
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
 )
 
 add_custom_target(
     PLATFORMIO_UPLOAD ALL
-    COMMAND ${PLATFORMIO_CMD} -f -c clion run --target upload
+    COMMAND ${PLATFORMIO_CMD} -f -c clion run --target upload "$<$<NOT:$<CONFIG:All>>:-e${CMAKE_BUILD_TYPE}>"
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
 )
 
 add_custom_target(
     PLATFORMIO_CLEAN ALL
-    COMMAND ${PLATFORMIO_CMD} -f -c clion run --target clean
+    COMMAND ${PLATFORMIO_CMD} -f -c clion run --target clean "$<$<NOT:$<CONFIG:All>>:-e${CMAKE_BUILD_TYPE}>"
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
 )
 
 add_custom_target(
     PLATFORMIO_MONITOR ALL
-    COMMAND ${PLATFORMIO_CMD} -f -c clion device monitor
+    COMMAND ${PLATFORMIO_CMD} -f -c clion device monitor "$<$<NOT:$<CONFIG:All>>:-e${CMAKE_BUILD_TYPE}>"
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
 )
 
 add_custom_target(
     PLATFORMIO_TEST ALL
-    COMMAND ${PLATFORMIO_CMD} -f -c clion test
+    COMMAND ${PLATFORMIO_CMD} -f -c clion test "$<$<NOT:$<CONFIG:All>>:-e${CMAKE_BUILD_TYPE}>"
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
 )
 
 add_custom_target(
     PLATFORMIO_PROGRAM ALL
-    COMMAND ${PLATFORMIO_CMD} -f -c clion run --target program
+    COMMAND ${PLATFORMIO_CMD} -f -c clion run --target program "$<$<NOT:$<CONFIG:All>>:-e${CMAKE_BUILD_TYPE}>"
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
 )
 
 add_custom_target(
     PLATFORMIO_UPLOADFS ALL
-    COMMAND ${PLATFORMIO_CMD} -f -c clion run --target uploadfs
+    COMMAND ${PLATFORMIO_CMD} -f -c clion run --target uploadfs "$<$<NOT:$<CONFIG:All>>:-e${CMAKE_BUILD_TYPE}>"
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
 )
 

--- a/platformio/ide/tpls/clion/CMakeListsPrivate.txt.tpl
+++ b/platformio/ide/tpls/clion/CMakeListsPrivate.txt.tpl
@@ -5,7 +5,7 @@
 # please create `CMakeListsUser.txt` in the root of project.
 # The `CMakeListsUser.txt` will not be overwritten by PlatformIO.
 
-%from platformio.project.helpers import (get_project_dir,load_project_ide_data)
+%from platformio.project.helpers import (load_project_ide_data)
 %
 % import re
 %
@@ -23,7 +23,6 @@
 % end
 %
 % envs = config.envs()
-% project_dir = get_project_dir()
 
 % if len(envs) > 1:
 set(CMAKE_CONFIGURATION_TYPES "{{ ";".join(envs) }}" CACHE STRING "" FORCE)
@@ -56,7 +55,7 @@ if (CMAKE_BUILD_TYPE MATCHES {{ env }})
 %   end
 
 %   for include in items["includes"]:
-    include_directories("{{ _normalize_path(include) }}")
+    include_directories("{{ _normalize_path(to_unix_path(include)) }}")
 %   end
 endif()
 % end

--- a/platformio/ide/tpls/clion/CMakeListsPrivate.txt.tpl
+++ b/platformio/ide/tpls/clion/CMakeListsPrivate.txt.tpl
@@ -5,6 +5,8 @@
 # please create `CMakeListsUser.txt` in the root of project.
 # The `CMakeListsUser.txt` will not be overwritten by PlatformIO.
 
+%from platformio.project.helpers import (get_project_dir,load_project_ide_data)
+%
 % import re
 %
 % def _normalize_path(path):
@@ -18,6 +20,14 @@
 %     end
 %   end
 %   return path
+% end
+%
+% envs = config.envs()
+
+% if len(envs) > 1:
+set(CMAKE_CONFIGURATION_TYPES "{{ ";".join(envs) }}" CACHE STRING "" FORCE)
+% else:
+set(CMAKE_CONFIGURATION_TYPES "{{ env_name }}" CACHE STRING "" FORCE)
 % end
 
 set(PLATFORMIO_CMD "{{ _normalize_path(platformio_path) }}")
@@ -37,12 +47,16 @@ SET(CMAKE_C_STANDARD {{ cc_stds[-1] }})
 set(CMAKE_CXX_STANDARD {{ cxx_stds[-1] }})
 % end
 
-% for define in defines:
-add_definitions(-D'{{!re.sub(r"([\"\(\)#])", r"\\\1", define)}}')
-% end
+% for env in envs:
+if (CMAKE_BUILD_TYPE MATCHES {{ env }})
+%   items = load_project_ide_data(get_project_dir(),env)
+%   for define in items["defines"]:
+    add_definitions(-D'{{!re.sub(r"([\"\(\)#])", r"\\\1", define)}}')
+%   end
 
-% for include in includes:
-include_directories("{{ _normalize_path(include) }}")
+%   for include in items["includes"]:
+    include_directories("{{ _normalize_path(include) }}")
+%   end
+endif()
 % end
-
 FILE(GLOB_RECURSE SRC_LIST "{{ _normalize_path(project_src_dir) }}/*.*" "{{ _normalize_path(project_lib_dir) }}/*.*" "{{ _normalize_path(project_libdeps_dir) }}/*.*")

--- a/platformio/ide/tpls/clion/CMakeListsPrivate.txt.tpl
+++ b/platformio/ide/tpls/clion/CMakeListsPrivate.txt.tpl
@@ -23,6 +23,7 @@
 % end
 %
 % envs = config.envs()
+% project_dir = get_project_dir()
 
 % if len(envs) > 1:
 set(CMAKE_CONFIGURATION_TYPES "{{ ";".join(envs) }}" CACHE STRING "" FORCE)
@@ -49,7 +50,7 @@ set(CMAKE_CXX_STANDARD {{ cxx_stds[-1] }})
 
 % for env in envs:
 if (CMAKE_BUILD_TYPE MATCHES {{ env }})
-%   items = load_project_ide_data(get_project_dir(),env)
+%   items = load_project_ide_data(project_dir,env)
 %   for define in items["defines"]:
     add_definitions(-D'{{!re.sub(r"([\"\(\)#])", r"\\\1", define)}}')
 %   end


### PR DESCRIPTION
Better CLion integration using the new access to ProjectConfig from ProjectGenerator ( 1dc15326c9d5d3e894e20d5ed2dfc89d4c9358e1 ).

Thanks to the changes this was much cleaner and faster to do. I would have preferred not to use `load_project_ide_data()` to get the full list of includes and defines but I could not figure how to do it easily just with `config`.

Currently the build profile allowing to run every environment (previous behaviour) is the last on the list, would you prefer it to be the default  ?