### PR TITLE
Adding .ccls file to support ccls on vim

### DIFF
--- a/platformio/ide/tpls/vim/.ccls.tpl
+++ b/platformio/ide/tpls/vim/.ccls.tpl
@@ -1,0 +1,7 @@
+clang
+% for include in includes:
+-I{{include}}
+% end
+% for define in defines:
+-D{{!define}}
+% end


### PR DESCRIPTION
.clang_complete is not loaded by ccls, so I created this file and worked fine using coc.nvim and ccls 