### PR TITLE
Stop ModemManager corrupting Arduino uploads

### DIFF
--- a/scripts/99-platformio-udev.rules
+++ b/scripts/99-platformio-udev.rules
@@ -40,8 +40,8 @@ SUBSYSTEMS=="usb", ATTRS{idVendor}=="067b", ATTRS{idProduct}=="2303", MODE:="066
 SUBSYSTEMS=="usb", ATTRS{idVendor}=="1a86", ATTRS{idProduct}=="7523", MODE:="0666"
 
 # Arduino boards
-SUBSYSTEMS=="usb", ATTRS{idVendor}=="2341", ATTRS{idProduct}=="[08][02]*", MODE:="0666"
-SUBSYSTEMS=="usb", ATTRS{idVendor}=="2a03", ATTRS{idProduct}=="[08][02]*", MODE:="0666"
+SUBSYSTEMS=="usb", ATTRS{idVendor}=="2341", ATTRS{idProduct}=="[08][02]*", MODE:="0666", ENV{ID_MM_DEVICE_IGNORE}="1", ENV{ID_MM_PORT_IGNORE}="1"
+SUBSYSTEMS=="usb", ATTRS{idVendor}=="2a03", ATTRS{idProduct}=="[08][02]*", MODE:="0666", ENV{ID_MM_DEVICE_IGNORE}="1", ENV{ID_MM_PORT_IGNORE}="1"
 
 # Arduino SAM-BA
 ATTRS{idVendor}=="03eb", ATTRS{idProduct}=="6124", ENV{ID_MM_DEVICE_IGNORE}="1"


### PR DESCRIPTION
On boards like the Arduino Micro, when in bootloader mode it appears ModemManager interferes with the programming process and result in a catastrophic failure with no end of different errors including, but not limited to:
```
error: programmer did not respond to command: write block
error: butterfly programmer uses avr_write_page() but does not provide a cmd() method.
error: programmer did not respond to command: set addr
```
After this, the device could appear to be completely non-functional, refusing to enumerate or appear for programming, but thankfully a double-reset will usually recover it, but the underlying ModemManager issue will still prevent successful programming. Hence the additional rules. 

This affects not only PlatformIO, but also the Arduino IDE (on linux). 

For my device, I only needed the first of two lines edited, but might as well do both as it will likely cause problems for all the range. I have not tested this outside of my own development box, but ModemManager is the cause of no end of Arduino upload issues on linux. 