### PR TITLE
Run client child process with a pty

### DIFF
--- a/platformio/commands/debug/client.py
+++ b/platformio/commands/debug/client.py
@@ -102,7 +102,8 @@ class GDBClient(BaseProcess):  # pylint: disable=too-many-instance-attributes
                                     gdb_path,
                                     args,
                                     path=self.project_dir,
-                                    env=os.environ)
+                                    env=os.environ
+                                    usePTY=True)
 
     @staticmethod
     def _get_data_dir(gdb_path):


### PR DESCRIPTION
Setting `usePTY` allows better interaction with GDB. `usePTY` is recommended when programs primarily interact with users via a terminal. 