### PR TITLE
UTF8 decoding should ignore invalid characters coming from the serial connection

### DIFF
--- a/platformio/commands/test/embedded.py
+++ b/platformio/commands/test/embedded.py
@@ -90,7 +90,7 @@ class EmbeddedTestProcessor(TestProcessorBase):
             if not line:
                 continue
             if isinstance(line, bytes):
-                line = line.decode("utf8")
+                line = line.decode("utf8", "ignore")
             self.on_run_out(line)
             if all([l in line for l in ("Tests", "Failures", "Ignored")]):
                 break


### PR DESCRIPTION
Some boards, like ESP32 based boards, give some unintelligible data when connecting to them via Serial. This is sometimes data that is send with the wrong baud rate (hard baked into the boot loader), or something else. It's hard to prevent this from happening. When a build is uploaded to the ESP board for unit testing, the decoding of the incoming stream should not fail the test due to some garbled content. Since the read data is validated on line 95, any garbage is automatically ignored and only outputted to the console.