### PR TITLE
CMake IDE/TPL added

### DIFF
--- a/platformio/ide/tpls/cmake/.gitignore.tpl
+++ b/platformio/ide/tpls/cmake/.gitignore.tpl
@@ -1,0 +1,2 @@
+.pio
+CMakeListsPrivate.txt

--- a/platformio/ide/tpls/cmake/CMakeLists.txt.tpl
+++ b/platformio/ide/tpls/cmake/CMakeLists.txt.tpl
@@ -1,0 +1,83 @@
+# !!! WARNING !!! AUTO-GENERATED FILE, PLEASE DO NOT MODIFY IT AND USE
+# https://docs.platformio.org/page/projectconf/section_env_build.html#build-flags
+#
+# If you need to override existing CMake configuration or add extra,
+# please create `CMakeListsUser.txt` in the root of project.
+# The `CMakeListsUser.txt` will not be overwritten by PlatformIO.
+
+cmake_minimum_required(VERSION 3.2)
+project({{project_name}})
+
+include(CMakeListsPrivate.txt)
+
+if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/CMakeListsUser.txt)
+include(CMakeListsUser.txt)
+endif()
+
+add_custom_target(
+    PLATFORMIO_BUILD ALL
+    COMMAND ${PLATFORMIO_CMD} -f -c cmake run "$<$<NOT:$<CONFIG:All>>:-e${CMAKE_BUILD_TYPE}>"
+    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+)
+
+add_custom_target(
+    PLATFORMIO_BUILD_VERBOSE ALL
+    COMMAND ${PLATFORMIO_CMD} -f -c cmake run --verbose "$<$<NOT:$<CONFIG:All>>:-e${CMAKE_BUILD_TYPE}>"
+    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+)
+
+add_custom_target(
+    PLATFORMIO_UPLOAD ALL
+    COMMAND ${PLATFORMIO_CMD} -f -c cmake run --target upload "$<$<NOT:$<CONFIG:All>>:-e${CMAKE_BUILD_TYPE}>"
+    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+)
+
+add_custom_target(
+    PLATFORMIO_CLEAN ALL
+    COMMAND ${PLATFORMIO_CMD} -f -c cmake run --target clean "$<$<NOT:$<CONFIG:All>>:-e${CMAKE_BUILD_TYPE}>"
+    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+)
+
+add_custom_target(
+    PLATFORMIO_MONITOR ALL
+    COMMAND ${PLATFORMIO_CMD} -f -c cmake device monitor "$<$<NOT:$<CONFIG:All>>:-e${CMAKE_BUILD_TYPE}>"
+    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+)
+
+add_custom_target(
+    PLATFORMIO_TEST ALL
+    COMMAND ${PLATFORMIO_CMD} -f -c cmake test "$<$<NOT:$<CONFIG:All>>:-e${CMAKE_BUILD_TYPE}>"
+    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+)
+
+add_custom_target(
+    PLATFORMIO_PROGRAM ALL
+    COMMAND ${PLATFORMIO_CMD} -f -c cmake run --target program "$<$<NOT:$<CONFIG:All>>:-e${CMAKE_BUILD_TYPE}>"
+    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+)
+
+add_custom_target(
+    PLATFORMIO_UPLOADFS ALL
+    COMMAND ${PLATFORMIO_CMD} -f -c cmake run --target uploadfs "$<$<NOT:$<CONFIG:All>>:-e${CMAKE_BUILD_TYPE}>"
+    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+)
+
+add_custom_target(
+    PLATFORMIO_UPDATE_ALL ALL
+    COMMAND ${PLATFORMIO_CMD} -f -c cmake update
+    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+)
+
+add_custom_target(
+    PLATFORMIO_REBUILD_PROJECT_INDEX ALL
+    COMMAND ${PLATFORMIO_CMD} -f -c cmake init --ide cmake
+    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+)
+
+add_custom_target(
+    PLATFORMIO_DEVICE_LIST ALL
+    COMMAND ${PLATFORMIO_CMD} -f -c cmake device list
+    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+)
+
+add_executable(${PROJECT_NAME} ${SRC_LIST})

--- a/platformio/ide/tpls/cmake/CMakeListsPrivate.txt.tpl
+++ b/platformio/ide/tpls/cmake/CMakeListsPrivate.txt.tpl
@@ -1,0 +1,80 @@
+# !!! WARNING !!! AUTO-GENERATED FILE, PLEASE DO NOT MODIFY IT AND USE
+# https://docs.platformio.org/page/projectconf/section_env_build.html#build-flags
+#
+# If you need to override existing CMake configuration or add extra,
+# please create `CMakeListsUser.txt` in the root of project.
+# The `CMakeListsUser.txt` will not be overwritten by PlatformIO.
+
+%from platformio.project.helpers import (load_project_ide_data)
+%
+% import re
+%
+% def _normalize_path(path):
+%   if project_dir in path:
+%     path = path.replace(project_dir, "${CMAKE_CURRENT_LIST_DIR}")
+%   elif user_home_dir in path:
+%     if "windows" in systype:
+%       path = path.replace(user_home_dir, "$ENV{HOMEDRIVE}$ENV{HOMEPATH}")
+%     else:
+%       path = path.replace(user_home_dir, "$ENV{HOME}")
+%     end
+%   end
+%   return path
+% end
+%
+% envs = config.envs()
+
+% if len(envs) > 1:
+set(CMAKE_CONFIGURATION_TYPES "{{ ";".join(envs) }}" CACHE STRING "" FORCE)
+message("Build Types: {{ ", ".join(envs) }}")
+% else:
+set(CMAKE_CONFIGURATION_TYPES "{{ env_name }}" CACHE STRING "" FORCE)
+message("Build Types: {{ env_name }}")
+% end
+
+set(PLATFORMIO_CMD "{{ _normalize_path(platformio_path) }}")
+
+SET(CMAKE_C_COMPILER "{{ _normalize_path(cc_path) }}")
+SET(CMAKE_CXX_COMPILER "{{ _normalize_path(cxx_path) }}")
+SET(CMAKE_CXX_FLAGS_DISTRIBUTION "{{cxx_flags}}")
+SET(CMAKE_C_FLAGS_DISTRIBUTION "{{cc_flags}}")
+
+% STD_RE = re.compile(r"\-std=[a-z\+]+(\d+)")
+% cc_stds = STD_RE.findall(cc_flags)
+% cxx_stds = STD_RE.findall(cxx_flags)
+% if cc_stds:
+SET(CMAKE_C_STANDARD {{ cc_stds[-1] }})
+% end
+% if cxx_stds:
+set(CMAKE_CXX_STANDARD {{ cxx_stds[-1] }})
+% end
+
+if (CMAKE_BUILD_TYPE MATCHES "{{ env_name }}")
+%for define in defines:
+    add_definitions(-D'{{!re.sub(r"([\"\(\)#])", r"\\\1", define)}}')
+%end
+
+%for include in includes:
+    include_directories("{{ _normalize_path(to_unix_path(include)) }}")
+%end
+endif()
+
+% leftover_envs = list(set(envs) ^ set([env_name]))
+%
+% ide_data = {}
+% if leftover_envs:
+%   ide_data = load_project_ide_data(project_dir, leftover_envs)
+% end
+%
+% for env, data in ide_data.items():
+if (CMAKE_BUILD_TYPE MATCHES "{{ env }}")
+%   for define in data["defines"]:
+    add_definitions(-D'{{!re.sub(r"([\"\(\)#])", r"\\\1", define)}}')
+%   end
+
+%   for include in data["includes"]:
+    include_directories("{{ _normalize_path(to_unix_path(include)) }}")
+%   end
+endif()
+% end
+FILE(GLOB_RECURSE SRC_LIST "{{ _normalize_path(project_src_dir) }}/*.*" "{{ _normalize_path(project_lib_dir) }}/*.*" "{{ _normalize_path(project_libdeps_dir) }}/*.*")


### PR DESCRIPTION
This is very helpful when working with cmake without a specific IDE.

```
# Create new cmake project
platformio init --ide cmake --board <ID>
```
11 predefined targets for building
```
PLATFORMIO_BUILD - Build project without auto-uploading
PLATFORMIO_BUILD_VERBOSE - Build project without auto-uploading in verbose mode
PLATFORMIO_UPLOAD - Build and upload (if no errors)
PLATFORMIO_CLEAN - Clean compiled objects
PLATFORMIO_MONITOR - Device monitor platformio device monitor
PLATFORMIO_TEST - PIO Unit Testing
PLATFORMIO_PROGRAM - Build and upload using external programmer (if no errors), see Upload using Programmer
PLATFORMIO_UPLOADFS - Upload files to file system SPIFFS, see Uploading files to file system SPIFFS
PLATFORMIO_UPDATE - Update installed platforms and libraries via platformio update
PLATFORMIO_REBUILD_PROJECT_INDEX - Rebuild C/C++ Index for the Project. Allows one to fix code completion and code linting issues.
PLATFORMIO_DEVICE_LIST - List connected devices.
```

I use it on two big projects and it works great. I hope you'll add it for everyone.
