### PR TITLE
Replace deprecated in python3: iteritems with items and basestr with str

### DIFF
--- a/scripts/get-platformio.py
+++ b/scripts/get-platformio.py
@@ -69,8 +69,8 @@ def exec_command(*args, **kwargs):
     result['out'], result['err'] = p.communicate()
     result['returncode'] = p.returncode
 
-    for k, v in result.iteritems():
-        if v and isinstance(v, basestring):
+    for k, v in result.items():
+        if v and isinstance(v, str):
             result[k].strip()
 
     return result


### PR DESCRIPTION
Fixes:
```
'dict' object has no attribute 'iteritems'
[FAILURE]
```
and
```
name 'basestring' is not defined
```
when run with Python3.5+ on Windows