### PR TITLE
Project is always compiling all the files

### DIFF
--- a/platformio/builder/main.py
+++ b/platformio/builder/main.py
@@ -142,7 +142,7 @@ env.LoadPioPlatform()
 
 env.SConscriptChdir(0)
 env.SConsignFile(
-    join("$BUILD_DIR", ".sconsign.py%d%d" % (sys.version_info[0], sys.version_info[1]))
+    join("$BUILD_DIR", ".sconsign.dblite")
 )
 
 for item in env.GetExtraScripts("pre"):


### PR DESCRIPTION
This is related to this bug : https://gavv.github.io/articles/sconsign-bug/
If the project contains many files, like a project based on the mbedos project, it will always compile every files and debugging is not possible anymore due to this error:
`
*** [.pio/build/disco_f746ng/FrameworkMbed/targets/TARGET_STM/TARGET_STM32F7/device/stm32f7xx_hal_cryp_ex.o] /Users/username/src/projectname/gsboard-v2/.pio/build/disco_f746ng/FrameworkMbed/targets/TARGET_STM/TARGET_STM32F7/device/stm32f7xx_hal_cryp_ex.o: No such file or directory
FileNotFoundError: [Errno 2] No such file or directory: '/Users/username/src/projectname/gsboard-v2/.pio/build/disco_f746ng/.sconsign.py37.dblite':
  File "/Users/username/.platformio/packages/tool-scons/script/../engine/SCons/Script/Main.py", line 1374:
    _exec_main(parser, values)
`

This small change correct this problem

Related issue:
https://github.com/platformio/platformio-core/issues/3304

