### PR TITLE
Add new debug_build_flags option

### DIFF
--- a/platformio/project/options.py
+++ b/platformio/project/options.py
@@ -602,6 +602,16 @@ ProjectOptions = OrderedDict(
             ),
             ConfigEnvOption(
                 group="debug",
+                name="debug_build_flags",
+                description=(
+                    "Custom debug flags/options for preprocessing, compilation, "
+                    "assembly, and linking processes"
+                ),
+                multiple=True,
+                default=["-Og", "-g2", "-ggdb2"],
+            ),
+            ConfigEnvOption(
+                group="debug",
                 name="debug_init_break",
                 description=(
                     "An initial breakpoint that makes program stop whenever a "

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -112,3 +112,61 @@ int main() {
     assert "-DTMP_MACRO1" not in build_output
     assert "-Os" not in build_output
     assert str(tmpdir) not in build_output
+
+
+def test_debug_default_build_flags(clirunner, validate_cliresult, tmpdir):
+    tmpdir.join("platformio.ini").write(
+        """
+[env:native]
+platform = native
+build_type = debug
+"""
+    )
+
+    tmpdir.mkdir("src").join("main.c").write(
+        """
+int main() {
+}
+"""
+    )
+
+    result = clirunner.invoke(cmd_run, ["--project-dir", str(tmpdir), "--verbose"])
+    validate_cliresult(result)
+    build_output = result.output[result.output.find("Scanning dependencies...") :]
+    for line in build_output.split("\n"):
+        if line.startswith("gcc"):
+            assert all(line.count(flag) == 1 for flag in ("-Og", "-g2", "-ggdb2"))
+            assert all(line.count("-%s%d" % (flag, level)) == 0 for flag in (
+                "O", "g", "ggdb") for level in (0, 1, 3))
+            assert "-Os" not in line
+
+
+def test_debug_custom_build_flags(clirunner, validate_cliresult, tmpdir):
+    custom_debug_build_flags = ("-O3", "-g3", "-ggdb3")
+
+    tmpdir.join("platformio.ini").write(
+        """
+[env:native]
+platform = native
+build_type = debug
+debug_build_flags = %s
+    """
+        % " ".join(custom_debug_build_flags)
+    )
+
+    tmpdir.mkdir("src").join("main.c").write(
+        """
+int main() {
+}
+"""
+    )
+
+    result = clirunner.invoke(cmd_run, ["--project-dir", str(tmpdir), "--verbose"])
+    validate_cliresult(result)
+    build_output = result.output[result.output.find("Scanning dependencies...") :]
+    for line in build_output.split("\n"):
+        if line.startswith("gcc"):
+            assert all(line.count(f) == 1 for f in custom_debug_build_flags)
+            assert all(line.count("-%s%d" % (flag, level)) == 0 for flag in (
+                "O", "g", "ggdb") for level in (0, 1, 2))
+            assert all("-O%s" % optimization not in line for optimization in ("g", "s"))


### PR DESCRIPTION
This will allow users to override default debug flags for example in cases when the final binary built in debug mode is too large to be loaded on target (e.g. https://github.com/platformio/platform-ststm32/issues/341)