### PR TITLE
Update templates for Atom, VSCode, CLion

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -31,6 +31,7 @@ PlatformIO Core 4.0
 * Fixed default PIO Unified Debugger configuration for `J-Link probe <http://docs.platformio.org/page/plus/debug-tools/jlink.html>`__
 * Fixed an issue with LDF when header files not found if "libdeps_dir" is within a subdirectory of "lib_extra_dirs" (`issue #3311 <https://github.com/platformio/platformio-core/issues/3311>`_)
 * Fixed an issue "Import of non-existent variable 'projenv''" when development platform does not call "env.BuildProgram()" (`issue #3315 <https://github.com/platformio/platformio-core/issues/3315>`_)
+* Fixed an issue with improperly handled compiler flags with space symbols in VSCode template (`issue #3364 <https://github.com/platformio/platformio-core/issues/3364>`_)
 
 4.1.0 (2019-11-07)
 ~~~~~~~~~~~~~~~~~~

--- a/platformio/builder/tools/pioide.py
+++ b/platformio/builder/tools/pioide.py
@@ -139,8 +139,7 @@ def _get_svd_path(env):
 
 
 def _escape_build_flag(flags):
-    result = [flag if " " not in flag else '"%s"' % flag for flag in flags]
-    return result
+    return [flag if " " not in flag else '"%s"' % flag for flag in flags]
 
 
 def DumpIDEData(env):

--- a/platformio/builder/tools/pioide.py
+++ b/platformio/builder/tools/pioide.py
@@ -138,9 +138,17 @@ def _get_svd_path(env):
     return None
 
 
+def _escape_build_flag(flags):
+    result = [flag if " " not in flag else '"%s"' % flag for flag in flags]
+    return result
+
+
 def DumpIDEData(env):
-    LINTCCOM = "$CFLAGS $CCFLAGS $CPPFLAGS"
-    LINTCXXCOM = "$CXXFLAGS $CCFLAGS $CPPFLAGS"
+
+    env["__escape_build_flag"] = _escape_build_flag
+
+    LINTCCOM = "${__escape_build_flag(CFLAGS)} ${__escape_build_flag(CCFLAGS)} $CPPFLAGS"
+    LINTCXXCOM = "${__escape_build_flag(CXXFLAGS)} ${__escape_build_flag(CCFLAGS)} $CPPFLAGS"
 
     data = {
         "env_name": env["PIOENV"],

--- a/platformio/ide/tpls/atom/.gcc-flags.json.tpl
+++ b/platformio/ide/tpls/atom/.gcc-flags.json.tpl
@@ -1,8 +1,8 @@
 % _defines = " ".join(["-D%s" % d.replace(" ", "\\\\ ") for d in defines])
 {
   "execPath": "{{ cxx_path }}",
-  "gccDefaultCFlags": "-fsyntax-only {{! cc_flags.replace(' -MMD ', ' ').replace('"', '\\"') }} {{ !_defines.replace('"', '\\"') }}",
-  "gccDefaultCppFlags": "-fsyntax-only {{! cxx_flags.replace(' -MMD ', ' ').replace('"', '\\"') }} {{ !_defines.replace('"', '\\"') }}",
+  "gccDefaultCFlags": "-fsyntax-only {{! to_unix_path(cc_flags).replace(' -MMD ', ' ').replace('"', '\\"') }} {{ !_defines.replace('"', '\\"') }}",
+  "gccDefaultCppFlags": "-fsyntax-only {{! to_unix_path(cxx_flags).replace(' -MMD ', ' ').replace('"', '\\"') }} {{ !_defines.replace('"', '\\"') }}",
   "gccErrorLimit": 15,
   "gccIncludePaths": "{{ ','.join(includes) }}",
   "gccSuppressWarnings": false

--- a/platformio/ide/tpls/clion/CMakeListsPrivate.txt.tpl
+++ b/platformio/ide/tpls/clion/CMakeListsPrivate.txt.tpl
@@ -5,7 +5,7 @@
 # please create `CMakeListsUser.txt` in the root of project.
 # The `CMakeListsUser.txt` will not be overwritten by PlatformIO.
 
-%from platformio.project.helpers import (load_project_ide_data)
+% from platformio.project.helpers import (load_project_ide_data)
 %
 % import re
 %
@@ -20,6 +20,10 @@
 %     end
 %   end
 %   return path
+% end
+%
+% def _escape(text):
+%   return to_unix_path(text).replace('"', '\\"')
 % end
 %
 % envs = config.envs()
@@ -37,8 +41,8 @@ set(SVD_PATH "{{ _normalize_path(svd_path) }}")
 
 SET(CMAKE_C_COMPILER "{{ _normalize_path(cc_path) }}")
 SET(CMAKE_CXX_COMPILER "{{ _normalize_path(cxx_path) }}")
-SET(CMAKE_CXX_FLAGS "{{cxx_flags}}")
-SET(CMAKE_C_FLAGS "{{cc_flags}}")
+SET(CMAKE_CXX_FLAGS "{{ _normalize_path(to_unix_path(cxx_flags)) }}")
+SET(CMAKE_C_FLAGS "{{ _normalize_path(to_unix_path(cc_flags)) }}")
 
 % STD_RE = re.compile(r"\-std=[a-z\+]+(\d+)")
 % cc_stds = STD_RE.findall(cc_flags)

--- a/platformio/ide/tpls/vscode/.vscode/c_cpp_properties.json.tpl
+++ b/platformio/ide/tpls/vscode/.vscode/c_cpp_properties.json.tpl
@@ -13,6 +13,10 @@
 %   return to_unix_path(text).replace('"', '\\"')
 % end
 %
+% def _escape_required(flag):
+%   return " " in flag and systype == "windows"
+% end
+%
 % def _split_flags(flags):
 %   result = []
 %   i = 0
@@ -80,9 +84,6 @@
 % cc_stds = STD_RE.findall(cc_flags)
 % cxx_stds = STD_RE.findall(cxx_flags)
 %
-% # pass only architecture specific flags
-% cc_m_flags = " ".join([f.strip() for f in cc_flags.split(" ") if f.strip().startswith(("-m", "-i", "@"))])
-%
 % if cc_stds:
             "cStandard": "c{{ cc_stds[-1] }}",
 % end
@@ -91,7 +92,8 @@
 % end
             "compilerPath": "{{ cc_path }}",
             "compilerArgs": [
-% for flag in [f for f in _split_flags(cc_flags) if f.startswith(("-m", "-i", "@"))]:
+% for flag in [ '"%s"' % _escape(f) if _escape_required(f) else f for f in _split_flags(
+%       cc_flags) if f.startswith(("-m", "-i", "@"))]:
                 "{{ flag }}",
 % end
                 ""

--- a/platformio/ide/tpls/vscode/.vscode/c_cpp_properties.json.tpl
+++ b/platformio/ide/tpls/vscode/.vscode/c_cpp_properties.json.tpl
@@ -13,6 +13,31 @@
 %   return to_unix_path(text).replace('"', '\\"')
 % end
 %
+% def _split_flags(flags):
+%   result = []
+%   i = 0
+%   flags = flags.strip()
+%   while i < len(flags):
+%       current_arg = []
+%       while i < len(flags) and flags[i] != " ":
+%         if flags[i] == '"':
+%           quotes_idx = flags.find('"', i + 1)
+%           current_arg.extend(flags[i + 1:quotes_idx])
+%           i = quotes_idx + 1
+%         else:
+%           current_arg.append(flags[i])
+%           i = i + 1
+%         end
+%       end
+%       arg = "".join(current_arg)
+%       if arg.strip():
+%         result.append(arg.strip())
+%       end
+%       i = i + 1
+%   end
+%   return result
+% end
+%
 % cleaned_includes = []
 % for include in includes:
 %   if "toolchain-" not in dirname(commonprefix([include, cc_path])) and isdir(include):
@@ -64,7 +89,13 @@
 % if cxx_stds:
             "cppStandard": "c++{{ cxx_stds[-1] }}",
 % end
-            "compilerPath": "\"{{cc_path}}\" {{! _escape(cc_m_flags) }}"
+            "compilerPath": "{{ cc_path }}",
+            "compilerArgs": [
+% for flag in [f for f in _split_flags(cc_flags) if f.startswith(("-m", "-i", "@"))]:
+                "{{ flag }}",
+% end
+                ""
+            ]
         }
     ],
     "version": 4


### PR DESCRIPTION
This PR resolves cases when a compiler flag contains a path with spaces as argument (e.g. `-iprefix`, `-imacros`, etc). These flags are crucial for some IDEs to provide a better code completion experience (e.g. #3364).