### PR TITLE
Add ESP crash trace decoding to monitor

### DIFF
--- a/platformio/commands/device.py
+++ b/platformio/commands/device.py
@@ -319,7 +319,7 @@ def register_platform_filters(platform, project_dir, environment):
             continue
 
         dot = fn.find(".")
-        module = load_python_module("platformio.commands.device.monitor.%s" % fn[:dot], path)
+        module = load_python_module("platformio.commands.device.%s" % fn[:dot], path)
         for key in dir(module):
             member = getattr(module, key)
             try:

--- a/platformio/compat.py
+++ b/platformio/compat.py
@@ -58,7 +58,7 @@ if PY2:
     def path_to_unicode(path):
         if isinstance(path, unicode):
             return path
-        return path.decode(get_filesystem_encoding()).encode("utf-8")
+        return path.decode(get_filesystem_encoding())
 
     def hashlib_encode_data(data):
         if is_bytes(data):


### PR DESCRIPTION
TODO:
- [x] Test on Windows
- [x] Test with unicode in paths & Python 2

This PR has been split into three parts, this one implements an interface to add more filters into miniterm and more in in platform repos, adding filters to decode the traces:
* https://github.com/platformio/platform-espressif32/pull/286
* https://github.com/platformio/platform-espressif8266/pull/197

**Original text below:**
I've implemented automatic ESP crash trace decoding in the device monitor in platform.io. It is  using a miniterm filter, add `--filter=esp_exception_decoder` to `monitor_flags` to use it.

It looks like this with a debug build (the indented part is new): ![Screenshot_20200215_190846](https://user-images.githubusercontent.com/120108/74592997-39aff180-5027-11ea-998a-1b2ce128fef2.png)

This is pretty much just a proof of concept, I've got some questions:
1. It's pretty short implementation, but brings device-specific code into platformio-core, and it's rather hard to do it some other way because it has to edit the `miniterm.TRANSFORMATIONS` dict. I wasn't sure where to put it, so I just kind kept it in the device monitor, figured I'd ask you.
2. Is there some nicer way to find the path to `addr2line` and to the built firmware file?
3. Do you think some kind of automatic device detection is feasible, so that people don't have to add the `--filter=esp_exception_decoder`? Or perhaps we could include that flag in board configs for ESP devices?

Looking forward to your response!

Updates platformio/platform-espressif32#105
Updates platformio/platform-espressif8266#31