### PR TITLE
Ensure all commands in compilation_commands.json use absolute paths.

### DIFF
--- a/platformio/builder/tools/compilation_db.py
+++ b/platformio/builder/tools/compilation_db.py
@@ -75,6 +75,16 @@ def makeEmitCompilationDbEntry(comstr):
         :param env: Environment for use building this node
         :return: target(s), source(s)
         """
+        
+        # Resolve absolute path of toolchain
+        for cmd in ("CC", "CXX", "AS"):
+            if cmd not in env:
+                continue
+            if os.path.isabs(env[cmd]):
+                continue
+            env[cmd] = where_is_program(
+                env.subst("$%s" % cmd), env.subst("${ENV['PATH']}")
+            )
 
         dbtarget = __CompilationDbNode(source)
 
@@ -195,14 +205,6 @@ def generate(env, **kwargs):
     )
 
     def CompilationDatabase(env, target):
-        # Resolve absolute path of toolchain
-        for cmd in ("CC", "CXX", "AS"):
-            if cmd not in env:
-                continue
-            env[cmd] = where_is_program(
-                env.subst("$%s" % cmd), env.subst("${ENV['PATH']}")
-            )
-
         result = env.__COMPILATIONDB_Database(target=target, source=[])
 
         env.AlwaysBuild(result)

--- a/platformio/builder/tools/compilation_db.py
+++ b/platformio/builder/tools/compilation_db.py
@@ -75,7 +75,7 @@ def makeEmitCompilationDbEntry(comstr):
         :param env: Environment for use building this node
         :return: target(s), source(s)
         """
-        
+
         # Resolve absolute path of toolchain
         for cmd in ("CC", "CXX", "AS"):
             if cmd not in env:


### PR DESCRIPTION
By placing the `where_is_program` call into this function, all references to the compiler will be made absolute, instead of just ones in the top environment. For example, previously all references to the compiler for user source code would not use the full path in the compilation database, which broke `clangd`'s detection of system includes.