### PR TITLE
(wip) Shell complete

### DIFF
--- a/platformio/commands/__init__.py
+++ b/platformio/commands/__init__.py
@@ -15,6 +15,8 @@
 import os
 
 import click
+import click_completion
+click_completion.init()
 
 
 class PlatformioCLI(click.MultiCommand):

--- a/platformio/commands/completion.py
+++ b/platformio/commands/completion.py
@@ -3,7 +3,6 @@
 import click
 import click_completion
 import click_completion.core
-click_completion.init()
 
 @click.group("completion", short_help="Manage shell completions")
 def cli():

--- a/platformio/commands/completion.py
+++ b/platformio/commands/completion.py
@@ -1,0 +1,30 @@
+# c/p from https://github.com/click-contrib/click-completion/blob/master/examples/click-completion-command
+
+import click
+import click_completion
+import click_completion.core
+click_completion.init()
+
+@click.group("completion", short_help="Manage shell completions")
+def cli():
+    pass
+
+@cli.command("show", short_help="Show shell command code")
+@click.option('-i', '--case-insensitive/--no-case-insensitive', help="Case insensitive completion")
+@click.argument('shell', required=False, type=click_completion.DocumentedChoice(click_completion.core.shells))
+def completion_show(shell, case_insensitive):
+    """Show the click-completion-command completion code"""
+    extra_env = {'_CLICK_COMPLETION_COMMAND_CASE_INSENSITIVE_COMPLETE': 'ON'} if case_insensitive else {}
+    click.echo(click_completion.core.get_code(shell, extra_env=extra_env))
+
+
+@cli.command("install", short_help="Install shell completion files")
+@click.option('--append/--overwrite', help="Append the completion code to the file", default=None)
+@click.option('-i', '--case-insensitive/--no-case-insensitive', help="Case insensitive completion")
+@click.argument('shell', required=False, type=click_completion.DocumentedChoice(click_completion.core.shells))
+@click.argument('path', required=False)
+def completion_install(append, case_insensitive, shell, path):
+    """Install the click-completion-command completion"""
+    extra_env = {'_CLICK_COMPLETION_COMMAND_CASE_INSENSITIVE_COMPLETE': 'ON'} if case_insensitive else {}
+    shell, path = click_completion.core.install(shell=shell, path=path, append=append, extra_env=extra_env)
+    click.echo('%s completion installed in %s' % (shell, path))

--- a/setup.py
+++ b/setup.py
@@ -29,6 +29,7 @@ from platformio.compat import PY2, WINDOWS
 install_requires = [
     "bottle<0.13",
     "click>=5,<8%s" % (",!=7.1,!=7.1.1" if WINDOWS else ""),
+    "click-completion>=0.5.2",
     "colorama",
     "pyserial>=3,<4,!=3.3",
     "requests>=2.4.0,<3",


### PR DESCRIPTION
As suggested in #3435, proof of concept that click-complete works by c/p example code from click-completion
I have tested fish, seems to work so far. Only one strange issue so far - it always expands to a full option in cases like `pio run -e` -> `pio run --environment`

*edit:* see `pio completion show` & `pio completion install` for the shell code that it generates