### PR TITLE
CLion: Add paths to libraries specified via lib_extra_dirs option

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -15,7 +15,7 @@ PlatformIO Core 4
 * Fixed UnicodeDecodeError on Windows when network drive (NAS) is used (`issue #3417 <https://github.com/platformio/platformio-core/issues/3417>`_)
 * Fixed an issue when saving libraries in new project results in error "No option 'lib_deps' in section" (`issue #3442 <https://github.com/platformio/platformio-core/issues/3442>`_)
 * Fixed an incorrect node path used for pattern matching when processing middleware nodes
-* Fixed an issue with missing `lib_extra_dirs` option in SRC_LIST for CLion (`issue #3460 <https://github.com/platformio/platformio-core/issues/3460>`_)
+* Fixed an issue with missing ``lib_extra_dirs`` option in SRC_LIST for CLion (`issue #3460 <https://github.com/platformio/platformio-core/issues/3460>`_)
 
 4.3.1 (2020-03-20)
 ~~~~~~~~~~~~~~~~~~

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -15,6 +15,7 @@ PlatformIO Core 4
 * Fixed UnicodeDecodeError on Windows when network drive (NAS) is used (`issue #3417 <https://github.com/platformio/platformio-core/issues/3417>`_)
 * Fixed an issue when saving libraries in new project results in error "No option 'lib_deps' in section" (`issue #3442 <https://github.com/platformio/platformio-core/issues/3442>`_)
 * Fixed an incorrect node path used for pattern matching when processing middleware nodes
+* Fixed an issue with missing `lib_extra_dirs` option in SRC_LIST for CLion (`issue #3460 <https://github.com/platformio/platformio-core/issues/3460>`_)
 
 4.3.1 (2020-03-20)
 ~~~~~~~~~~~~~~~~~~

--- a/platformio/builder/tools/pioide.py
+++ b/platformio/builder/tools/pioide.py
@@ -138,6 +138,16 @@ def _get_svd_path(env):
     return None
 
 
+def _get_used_lib_includes(env):
+    lib_paths = []
+    for lb in env.GetLibBuilders():
+        if not lb.dependent:
+            continue
+        lb.env.PrependUnique(CPPPATH=lb.get_include_dirs())
+        lib_paths.extend(lb.env["CPPPATH"])
+    return lib_paths
+
+
 def _escape_build_flag(flags):
     return [flag if " " not in flag else '"%s"' % flag for flag in flags]
 
@@ -170,6 +180,8 @@ def DumpIDEData(env):
         ],
         "svd_path": _get_svd_path(env),
         "compiler_type": env.GetCompilerType(),
+        "lib_includes": _get_used_lib_includes(env),
+        "lib_extra_dirs": env.GetProjectOption("lib_extra_dirs", [])
     }
 
     env_ = env.Clone()

--- a/platformio/ide/projectgenerator.py
+++ b/platformio/ide/projectgenerator.py
@@ -57,6 +57,20 @@ class ProjectGenerator(object):
 
         return envname
 
+    @staticmethod
+    def filter_includes(includes_map, ignore_scopes=None, to_unix_path=True):
+        ignore_scopes = ignore_scopes or []
+        result = []
+        for scope, includes in includes_map.items():
+            if scope in ignore_scopes:
+                continue
+            for include in includes:
+                if to_unix_path:
+                    include = fs.to_unix_path(include)
+                if include not in result:
+                    result.append(include)
+        return result
+
     def _load_tplvars(self):
         tpl_vars = {
             "config": self.config,
@@ -92,12 +106,13 @@ class ProjectGenerator(object):
         for key, value in tpl_vars.items():
             if key.endswith(("_path", "_dir")):
                 tpl_vars[key] = fs.to_unix_path(value)
-        for key in ("includes", "src_files", "libsource_dirs"):
+        for key in ("src_files", "libsource_dirs"):
             if key not in tpl_vars:
                 continue
             tpl_vars[key] = [fs.to_unix_path(inc) for inc in tpl_vars[key]]
 
         tpl_vars["to_unix_path"] = fs.to_unix_path
+        tpl_vars["filter_includes"] = self.filter_includes
         return tpl_vars
 
     def get_src_files(self):

--- a/platformio/ide/tpls/atom/.clang_complete.tpl
+++ b/platformio/ide/tpls/atom/.clang_complete.tpl
@@ -1,4 +1,4 @@
-% for include in includes:
+% for include in filter_includes(includes):
 -I{{include}}
 % end
 % for define in defines:

--- a/platformio/ide/tpls/atom/.gcc-flags.json.tpl
+++ b/platformio/ide/tpls/atom/.gcc-flags.json.tpl
@@ -4,6 +4,6 @@
   "gccDefaultCFlags": "-fsyntax-only {{! to_unix_path(cc_flags).replace(' -MMD ', ' ').replace('"', '\\"') }} {{ !_defines.replace('"', '\\"') }}",
   "gccDefaultCppFlags": "-fsyntax-only {{! to_unix_path(cxx_flags).replace(' -MMD ', ' ').replace('"', '\\"') }} {{ !_defines.replace('"', '\\"') }}",
   "gccErrorLimit": 15,
-  "gccIncludePaths": "{{ ','.join(includes) }}",
+  "gccIncludePaths": "{{ ','.join(filter_includes(includes)) }}",
   "gccSuppressWarnings": false
 }

--- a/platformio/ide/tpls/codeblocks/platformio.cbp.tpl
+++ b/platformio/ide/tpls/codeblocks/platformio.cbp.tpl
@@ -52,7 +52,7 @@
 			% for define in defines:
 			<Add option="-D{{define}}"/>
 			% end
-			% for include in includes:
+			% for include in filter_includes(includes):
 			<Add directory="{{include}}"/>
 			% end
 		</Compiler>

--- a/platformio/ide/tpls/eclipse/.cproject.tpl
+++ b/platformio/ide/tpls/eclipse/.cproject.tpl
@@ -23,10 +23,8 @@
 							<tool id="org.eclipse.cdt.build.core.settings.holder.libs.1409095472" name="holder for library settings" superClass="org.eclipse.cdt.build.core.settings.holder.libs"/>
 							<tool id="org.eclipse.cdt.build.core.settings.holder.1624502120" name="Assembly" superClass="org.eclipse.cdt.build.core.settings.holder">
 								<option id="org.eclipse.cdt.build.core.settings.holder.incpaths.239157887" name="Include Paths" superClass="org.eclipse.cdt.build.core.settings.holder.incpaths" valueType="includePath">
-									% for include in includes:
-									% if "toolchain" in include:
-									% continue
-									% end
+									% cleaned_includes = filter_includes(includes, ["toolchain"])
+									% for include in cleaned_includes:
                                     % if include.startswith(user_home_dir):
                                     % if "windows" in systype:
 									<listOptionValue builtIn="false" value="${USERPROFILE}{{include.replace(user_home_dir, '')}}"/>
@@ -47,10 +45,7 @@
 							</tool>
 							<tool id="org.eclipse.cdt.build.core.settings.holder.54121539" name="GNU C++" superClass="org.eclipse.cdt.build.core.settings.holder">
 								<option id="org.eclipse.cdt.build.core.settings.holder.incpaths.1096940598" name="Include Paths" superClass="org.eclipse.cdt.build.core.settings.holder.incpaths" valueType="includePath">
-									% for include in includes:
-									% if "toolchain" in include:
-									% continue
-									% end
+									% for include in cleaned_includes:
                                     % if include.startswith(user_home_dir):
                                     % if "windows" in systype:
 									<listOptionValue builtIn="false" value="${USERPROFILE}{{include.replace(user_home_dir, '')}}"/>
@@ -71,10 +66,7 @@
 							</tool>
 							<tool id="org.eclipse.cdt.build.core.settings.holder.1310559623" name="GNU C" superClass="org.eclipse.cdt.build.core.settings.holder">
 								<option id="org.eclipse.cdt.build.core.settings.holder.incpaths.41298875" name="Include Paths" superClass="org.eclipse.cdt.build.core.settings.holder.incpaths" valueType="includePath">
-									% for include in includes:
-									% if "toolchain" in include:
-									% continue
-									% end
+									% for include in cleaned_includes:
                                     % if include.startswith(user_home_dir):
                                     % if "windows" in systype:
 									<listOptionValue builtIn="false" value="${USERPROFILE}{{include.replace(user_home_dir, '')}}"/>
@@ -121,10 +113,7 @@
 							<tool id="org.eclipse.cdt.build.core.settings.holder.libs.1855678035" name="holder for library settings" superClass="org.eclipse.cdt.build.core.settings.holder.libs"/>
 							<tool id="org.eclipse.cdt.build.core.settings.holder.30528994" name="Assembly" superClass="org.eclipse.cdt.build.core.settings.holder">
 								<option id="org.eclipse.cdt.build.core.settings.holder.incpaths.794801023" name="Include Paths" superClass="org.eclipse.cdt.build.core.settings.holder.incpaths" valueType="includePath">
-									% for include in includes:
-									% if "toolchain" in include:
-									% continue
-									% end
+									% for include in cleaned_includes:
                                     % if include.startswith(user_home_dir):
                                     % if "windows" in systype:
 									<listOptionValue builtIn="false" value="${USERPROFILE}{{include.replace(user_home_dir, '')}}"/>
@@ -145,10 +134,7 @@
 							</tool>
 							<tool id="org.eclipse.cdt.build.core.settings.holder.1146422798" name="GNU C++" superClass="org.eclipse.cdt.build.core.settings.holder">
 								<option id="org.eclipse.cdt.build.core.settings.holder.incpaths.650084869" name="Include Paths" superClass="org.eclipse.cdt.build.core.settings.holder.incpaths" useByScannerDiscovery="false" valueType="includePath">
-									% for include in includes:
-									% if "toolchain" in include:
-									% continue
-									% end
+									% for include in cleaned_includes:
                                     % if include.startswith(user_home_dir):
                                     % if "windows" in systype:
 									<listOptionValue builtIn="false" value="${USERPROFILE}{{include.replace(user_home_dir, '')}}"/>
@@ -169,10 +155,7 @@
 							</tool>
 							<tool id="org.eclipse.cdt.build.core.settings.holder.1637357529" name="GNU C" superClass="org.eclipse.cdt.build.core.settings.holder">
 								<option id="org.eclipse.cdt.build.core.settings.holder.incpaths.1246337321" name="Include Paths" superClass="org.eclipse.cdt.build.core.settings.holder.incpaths" useByScannerDiscovery="false" valueType="includePath">
-									% for include in includes:
-									% if "toolchain" in include:
-									% continue
-									% end
+									% for include in cleaned_includes:
                                     % if include.startswith(user_home_dir):
                                     % if "windows" in systype:
 									<listOptionValue builtIn="false" value="${USERPROFILE}{{include.replace(user_home_dir, '')}}"/>

--- a/platformio/ide/tpls/emacs/.ccls.tpl
+++ b/platformio/ide/tpls/emacs/.ccls.tpl
@@ -13,7 +13,7 @@ clang
 {{"%cpp"}} -std=c++{{ cxx_stds[-1] }}
 % end
 
-% for include in includes:
+% for include in filter_includes(includes):
 -I{{ include }}
 % end
 

--- a/platformio/ide/tpls/emacs/.clang_complete.tpl
+++ b/platformio/ide/tpls/emacs/.clang_complete.tpl
@@ -1,4 +1,4 @@
-% for include in includes:
+% for include in filter_includes(includes):
 -I{{include}}
 % end
 % for define in defines:

--- a/platformio/ide/tpls/netbeans/nbproject/configurations.xml.tpl
+++ b/platformio/ide/tpls/netbeans/nbproject/configurations.xml.tpl
@@ -34,9 +34,10 @@
           <cleanCommand>{{platformio_path}} -f -c netbeans run --target clean</cleanCommand>
           <executablePath></executablePath>
           <cTool>
+            % cleaned_includes = filter_includes(includes)
             <incDir>
               <pElem>src</pElem>
-              % for include in includes:
+              % for include in cleaned_includes:
               <pElem>{{include}}</pElem>
               % end
             </incDir>
@@ -49,7 +50,7 @@
           <ccTool>
             <incDir>
               <pElem>src</pElem>
-              % for include in includes:
+              % for include in cleaned_includes:
               <pElem>{{include}}</pElem>
               % end
             </incDir>

--- a/platformio/ide/tpls/qtcreator/platformio.pro.tpl
+++ b/platformio/ide/tpls/qtcreator/platformio.pro.tpl
@@ -5,7 +5,7 @@ else {
     HOMEDIR += $$(HOME)
 }
 
-% for include in includes:
+% for include in filter_includes(includes):
 % if include.startswith(user_home_dir):
 INCLUDEPATH += "$${HOMEDIR}{{include.replace(user_home_dir, "")}}"
 % else:

--- a/platformio/ide/tpls/vim/.ccls.tpl
+++ b/platformio/ide/tpls/vim/.ccls.tpl
@@ -13,7 +13,7 @@ clang
 {{"%cpp"}} -std=c++{{ cxx_stds[-1] }}
 % end
 
-% for include in includes:
+% for include in filter_includes(includes):
 -I{{ include }}
 % end
 

--- a/platformio/ide/tpls/vim/.clang_complete.tpl
+++ b/platformio/ide/tpls/vim/.clang_complete.tpl
@@ -1,4 +1,4 @@
-% for include in includes:
+% for include in filter_includes(includes):
 -I"{{include}}"
 % end
 % for define in defines:

--- a/platformio/ide/tpls/vim/.gcc-flags.json.tpl
+++ b/platformio/ide/tpls/vim/.gcc-flags.json.tpl
@@ -4,6 +4,6 @@
   "gccDefaultCFlags": "-fsyntax-only {{! cc_flags.replace(' -MMD ', ' ').replace('"', '\\"') }} {{ !_defines.replace('"', '\\"') }}",
   "gccDefaultCppFlags": "-fsyntax-only {{! cxx_flags.replace(' -MMD ', ' ').replace('"', '\\"') }} {{ !_defines.replace('"', '\\"') }}",
   "gccErrorLimit": 15,
-  "gccIncludePaths": "{{ ','.join(includes) }}",
+  "gccIncludePaths": "{{ ','.join(filter_includes(includes)) }}",
   "gccSuppressWarnings": false
 }

--- a/platformio/ide/tpls/visualstudio/platformio.vcxproj.tpl
+++ b/platformio/ide/tpls/visualstudio/platformio.vcxproj.tpl
@@ -42,13 +42,14 @@
     <NMakeBuildCommandLine>platformio -f -c visualstudio run</NMakeBuildCommandLine>
     <NMakeCleanCommandLine>platformio -f -c visualstudio run --target clean</NMakeCleanCommandLine>
     <NMakePreprocessorDefinitions>{{!";".join(defines)}}</NMakePreprocessorDefinitions>
-    <NMakeIncludeSearchPath>{{";".join(["$(HOMEDRIVE)$(HOMEPATH)%s" % i.replace(user_home_dir, "") if i.startswith(user_home_dir) else i for i in includes])}}</NMakeIncludeSearchPath>
+    % cleaned_includes = filter_includes(includes)
+    <NMakeIncludeSearchPath>{{";".join(["$(HOMEDRIVE)$(HOMEPATH)%s" % i.replace(user_home_dir, "") if i.startswith(user_home_dir) else i for i in cleaned_includes])}}</NMakeIncludeSearchPath>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <NMakeBuildCommandLine>platformio run</NMakeBuildCommandLine>
     <NMakeCleanCommandLine>platformio run --target clean</NMakeCleanCommandLine>
     <NMakePreprocessorDefinitions>{{!";".join(defines)}}</NMakePreprocessorDefinitions>
-    <NMakeIncludeSearchPath>{{";".join(["$(HOMEDRIVE)$(HOMEPATH)%s" % i.replace(user_home_dir, "") if i.startswith(user_home_dir) else i for i in includes])}}</NMakeIncludeSearchPath>
+    <NMakeIncludeSearchPath>{{";".join(["$(HOMEDRIVE)$(HOMEPATH)%s" % i.replace(user_home_dir, "") if i.startswith(user_home_dir) else i for i in cleaned_includes])}}</NMakeIncludeSearchPath>
   </PropertyGroup>
   <ItemDefinitionGroup>
   </ItemDefinitionGroup>

--- a/platformio/ide/tpls/vscode/.vscode/c_cpp_properties.json.tpl
+++ b/platformio/ide/tpls/vscode/.vscode/c_cpp_properties.json.tpl
@@ -66,13 +66,7 @@
 %   return result
 % end
 %
-% cleaned_includes = []
-% for include in includes:
-%   if "toolchain-" not in os.path.dirname(os.path.commonprefix(
-%       [include, cc_path])) and os.path.isdir(include):
-%     cleaned_includes.append(include)
-%   end
-% end
+% cleaned_includes = filter_includes(includes, ["toolchain"])
 %
 % STD_RE = re.compile(r"\-std=[a-z\+]+(\d+)")
 % cc_stds = STD_RE.findall(cc_flags)


### PR DESCRIPTION
Should fix #3460. Besides, global folders in `SRC_LIST` paired with `GLOB_RECURSE` seem a bit unnecessary since there might be unused libraries in these folders