### PR TITLE
Fix #3535 - Spurious rebuilds

### DIFF
--- a/platformio/builder/tools/piolib.py
+++ b/platformio/builder/tools/piolib.py
@@ -1006,6 +1006,7 @@ def ConfigureProjectLibBuilder(env):
 
     def _print_deps_tree(root, level=0):
         margin = "|   " * (level)
+        root.depbuilders.sort(key=lambda lb: lb.path)
         for lb in root.depbuilders:
             title = "<%s>" % lb.name
             vcs_info = _get_vcs_info(lb)

--- a/platformio/builder/tools/piomaxlen.py
+++ b/platformio/builder/tools/piomaxlen.py
@@ -43,6 +43,7 @@ def long_sources_hook(env, sources):
 
 def long_incflags_hook(env, incflags):
     _incflags = env.subst(incflags).replace("\\", "/")
+    _incflags = " -I".join(sorted(_incflags.split(" -I")))
     if len(_incflags) < MAX_LINE_LENGTH:
         return incflags
 


### PR DESCRIPTION
This change eliminates spurious recompiles and relinks caused by indeterminate order of includes on the cpp command and indeterminate order of libraries on the linker command line.

I tried to follow the contribution guidelines, but the "make test" step failed even without my changes, so I do not trust the tests.