### PR TITLE
macOS don't support -Wl,--start-group/--end-group

### DIFF
--- a/platformio/builder/tools/platformio.py
+++ b/platformio/builder/tools/platformio.py
@@ -67,7 +67,7 @@ def BuildProgram(env):
         env.Prepend(LINKFLAGS=["-T", env.subst("$LDSCRIPT_PATH")])
 
     # enable "cyclic reference" for linker
-    if env.get("LIBS") and env.GetCompilerType() == "gcc" and env.get("PLATFORM") != "darwin":
+    if env.get("LIBS") and env.GetCompilerType() == "gcc" and (env.get('PIOPLATFORM') != 'native' or env.get("PLATFORM") != "darwin"):
         env.Prepend(_LIBFLAGS="-Wl,--start-group ")
         env.Append(_LIBFLAGS=" -Wl,--end-group")
 

--- a/platformio/builder/tools/platformio.py
+++ b/platformio/builder/tools/platformio.py
@@ -67,7 +67,7 @@ def BuildProgram(env):
         env.Prepend(LINKFLAGS=["-T", env.subst("$LDSCRIPT_PATH")])
 
     # enable "cyclic reference" for linker
-    if env.get("LIBS") and env.GetCompilerType() == "gcc":
+    if env.get("LIBS") and env.GetCompilerType() == "gcc" and env.get("PLATFORM") != "darwin":
         env.Prepend(_LIBFLAGS="-Wl,--start-group ")
         env.Append(_LIBFLAGS=" -Wl,--end-group")
 


### PR DESCRIPTION
Using Native platform in macOS fails to compile because the flags -Wl,--start-group/-Wl,--end-group aren't supported in macOS.
The native platform build script can't fix it because the core is adding this flags.

This changes fix that: macOS don't support -Wl,--start-group/-Wl,--end-group flags.