### PR TITLE
Add .ccls to .gitignore (vim and emacs)

### DIFF
--- a/platformio/ide/tpls/emacs/.gitignore.tpl
+++ b/platformio/ide/tpls/emacs/.gitignore.tpl
@@ -1,2 +1,3 @@
 .pio
 .clang_complete
+.ccls

--- a/platformio/ide/tpls/vim/.gitignore.tpl
+++ b/platformio/ide/tpls/vim/.gitignore.tpl
@@ -1,3 +1,4 @@
 .pio
 .clang_complete
 .gcc-flags.json
+.ccls


### PR DESCRIPTION
Adds `.ccls` in `.gitignore` for Vim (introduced in 223a85baca14150400e324ae39196be87822e265) and Emacs (introduced in 7a07a2e63eb51f8e403ecaf0fb2e4029d7b54744).

The file `.ccls` doesn't need to be tracked in git as it contains user/machine-related configurations (similar to `.clang_complete`).