### PR TITLE
Check lower case http_proxy environment variables

### DIFF
--- a/platformio/commands/home/helpers.py
+++ b/platformio/commands/home/helpers.py
@@ -59,8 +59,10 @@ def is_twitter_blocked():
     ip = "104.244.42.1"
     timeout = 2
     try:
-        if os.getenv("HTTP_PROXY", os.getenv("HTTPS_PROXY")):
-            requests.get("http://%s" % ip, allow_redirects=False, timeout=timeout)
+        for proxy in ["http_proxy", "https_proxy", "HTTP_PROXY", "HTTPS_PROXY"]:
+            if os.getenv(proxy):
+                requests.get("http://%s" % ip, allow_redirects=False, timeout=timeout)
+                break
         else:
             socket.socket(socket.AF_INET, socket.SOCK_STREAM).connect((ip, 80))
         return False

--- a/platformio/util.py
+++ b/platformio/util.py
@@ -377,8 +377,10 @@ def _internet_on():
     socket.setdefaulttimeout(timeout)
     for host in PING_REMOTE_HOSTS:
         try:
-            if os.getenv("HTTP_PROXY", os.getenv("HTTPS_PROXY")):
-                requests.get("http://%s" % host, allow_redirects=False, timeout=timeout)
+            for proxy in ["http_proxy", "https_proxy", "HTTP_PROXY", "HTTPS_PROXY"]:
+                if os.getenv(proxy):
+                    requests.get("http://%s" % host, allow_redirects=False, timeout=timeout)
+                    break
             else:
                 socket.socket(socket.AF_INET, socket.SOCK_STREAM).connect((host, 80))
             return True


### PR DESCRIPTION
Not all systems have their proxy environment variable set as uppercase. According to [stackoverflow](https://unix.stackexchange.com/questions/212894/whats-the-right-format-for-the-http-proxy-environment-variable-caps-or-no-ca) most of them don't. This is also the case for the system, I'm working with currently.