### PR TITLE
Exclude tests from python package setup

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,7 @@ setup(
         [">=2.7", "!=3.0.*", "!=3.1.*", "!=3.2.*", "!=3.3.*", "!=3.4.*"]
     ),
     install_requires=install_requires,
-    packages=find_packages() + ["scripts"],
+    packages=find_packages(exclude=["tests.*", "tests"]) + ["scripts"],
     package_data={
         "platformio": [
             "ide/tpls/*/.*.tpl",


### PR DESCRIPTION
The addition of the `tests/__init__.py` makes `find_packages()` recognize `tests` as additional python package. Now this unexpected module gets also installed by pip, possibly into system site-packages. This could cause conflicts with other packages, so I suggest excluding it again.