### PR TITLE
fix quoting of defines in ccls template

### DIFF
--- a/platformio/ide/tpls/vim/.ccls.tpl
+++ b/platformio/ide/tpls/vim/.ccls.tpl
@@ -18,5 +18,5 @@ clang
 % end
 
 % for define in defines:
--D{{ define }}
+-D{{ !define }}
 % end


### PR DESCRIPTION
This change fixes quoted strings in defines in the ccls vim template.

```diff
--DARDUINO_BOARD=&quot;PLATFORMIO_D1_MINI&quot;
+-DARDUINO_BOARD="PLATFORMIO_D1_MINI"
```