### PR TITLE
Added CONFIG += c++17 to get correct autocompletions

### DIFF
--- a/platformio/ide/tpls/qtcreator/platformio.pro.tpl
+++ b/platformio/ide/tpls/qtcreator/platformio.pro.tpl
@@ -27,3 +27,5 @@ HEADERS += {{file}}
 SOURCES += {{file}}
 % end
 % end
+
+CONFIG += c++17


### PR DESCRIPTION
I know this template is not perfect for everyone, as maybe someone still keeps compiling in some old, outdated c++ standard. Maybe you can guide me on how to properly detect, if the user is compiling in c++17 and add the missing conditions?

I personally target with almost all my projects the ESP32 with GCC 8.4.0 and I keep adding -std=gnu++17 or -std=gnu++2a to the compiler arguments to get all required features of the language.