### PR TITLE
Create `_gdbsrc_dir` temporary directory only if debug server launches successfully

### DIFF
--- a/platformio/commands/debug/process/client.py
+++ b/platformio/commands/debug/process/client.py
@@ -54,7 +54,7 @@ class GDBClient(BaseProcess):  # pylint: disable=too-many-instance-attributes
 
         if not isdir(get_project_cache_dir()):
             os.makedirs(get_project_cache_dir())
-        self._gdbsrc_dir = mkdtemp(dir=get_project_cache_dir(), prefix=".piodebug-")
+        self._gdbsrc_dir = None
 
         self._target_is_run = False
         self._auto_continue_timer = None
@@ -81,6 +81,7 @@ class GDBClient(BaseProcess):  # pylint: disable=too-many-instance-attributes
         if not patterns["DEBUG_PORT"]:
             patterns["DEBUG_PORT"] = self._debug_server.get_debug_port()
 
+        self._gdbsrc_dir = mkdtemp(dir=get_project_cache_dir(), prefix=".piodebug-")
         self.generate_pioinit(self._gdbsrc_dir, patterns)
 
         # start GDB client


### PR DESCRIPTION
This change postpones the creation of the `_gdbsrc_dir` temporary directory until **after** the debug server has successfully launched.

Previously, `_gdbsrc_dir` would be unconditionally created as soon as the `GDBClient` class was instantiated. If anything then went wrong in launching the debug server (e.g. due to an invalid user-provided `debug_server` with `debug_tool = custom`), the temporary directory would be left behind and never cleaned up.