### PR TITLE
Add compileCommands to `c_cpp_properties.json`

### DIFF
--- a/platformio/builder/tools/pioide.py
+++ b/platformio/builder/tools/pioide.py
@@ -167,6 +167,7 @@ def DumpIDEData(env, globalenv):
         "gdb_path": where_is_program(env.subst("$GDB"), env.subst("${ENV['PATH']}")),
         "prog_path": env.subst("$PROG_PATH"),
         "svd_path": _get_svd_path(env),
+        "compile_commands_path": env.subst("$COMPILATIONDB_PATH"),
         "compiler_type": env.GetCompilerType(),
         "targets": globalenv.DumpTargets(),
         "extra": dict(

--- a/platformio/ide/tpls/vscode/.vscode/c_cpp_properties.json.tpl
+++ b/platformio/ide/tpls/vscode/.vscode/c_cpp_properties.json.tpl
@@ -127,6 +127,7 @@
                 ""
             ],
 % end
+            "compileCommands": "{{ compile_commands_path }}",
             "compilerPath": "{{ cc_path }}",
             "compilerArgs": [
 % for flag in [


### PR DESCRIPTION
This makes vscode aware of the location of the `compile_commands.json` file.