### PR TITLE
A fix for compiler invocation from the PVS-Studio code check

### DIFF
--- a/platformio/commands/check/tools/pvsstudio.py
+++ b/platformio/commands/check/tools/pvsstudio.py
@@ -187,7 +187,13 @@ class PvsStudioCheckTool(CheckToolBase):  # pylint: disable=too-many-instance-at
             flags = self.cc_flags
             compiler = self.cc_path
 
-        cmd = [compiler, '"%s"' % src_file, "-E", "-o", '"%s"' % self._tmp_preprocessed_file]
+        cmd = [
+            compiler,
+            '"%s"' % src_file,
+            "-E",
+            "-o",
+            '"%s"' % self._tmp_preprocessed_file,
+        ]
         cmd.extend([f for f in flags if f])
         cmd.extend(["-D%s" % d for d in self.cpp_defines])
         cmd.append('@"%s"' % self._tmp_cmd_file)

--- a/platformio/commands/check/tools/pvsstudio.py
+++ b/platformio/commands/check/tools/pvsstudio.py
@@ -187,7 +187,7 @@ class PvsStudioCheckTool(CheckToolBase):  # pylint: disable=too-many-instance-at
             flags = self.cc_flags
             compiler = self.cc_path
 
-        cmd = [compiler, src_file, "-E", "-o", self._tmp_preprocessed_file]
+        cmd = [compiler, '"%s"' % src_file, "-E", "-o", '"%s"' % self._tmp_preprocessed_file]
         cmd.extend([f for f in flags if f])
         cmd.extend(["-D%s" % d for d in self.cpp_defines])
         cmd.append('@"%s"' % self._tmp_cmd_file)


### PR DESCRIPTION
I have a problem with PVS-Studio code check when the path to the project contains spaces.

`D:\platformio test>C:\Users\tester\.platformio\penv\Scripts\platformio.exe check -v`

```
Checking miniatmega328 > pvs-studio (platform: atmelavr; board: miniatmega328; framework: arduino)
------------------------------------------------------------------------------------------------------------------------
C:\Users\tester\.platformio\packages\toolchain-atmelavr\bin\avr-g++.exe D:\platformio test\src\main.cpp -E -o C:\Users\tester\AppData\Local\Temp\piocheckksjp2hbh\oxlnipks.i -fno-exceptions -fno-threadsafe-statics -fpermissive -std=gnu++11 -Os -Wall -ffunction-sections -fdata-sections -flto -mmcu=atmega328p -DPLATFORMIO=50100 -DARDUINO_AVR_MINI -DF_CPU=16000000L -DARDUINO_ARCH_AVR -DARDUINO=10808 -D__AVR_ATmega328P__ @"C:\Users\govorov\AppData\Local\Temp\piocheckksjp2hbh\e7adc2c0.cmd"
avr-g++.exe: error: D:\platformio: No such file or directory
avr-g++.exe: error: test\src\main.cpp: No such file or directory
avr-g++.exe: fatal error: no input files
compilation terminated.

Error: Missing preprocessed file for 'D:\platformio test\src\main.cpp'


Error: pvs-studio failed to perform check! Please examine tool output in verbose mode.
============================================== [FAILED] Took 0.02 seconds ==============================================

Environment    Tool        Status    Duration
-------------  ----------  --------  ------------
miniatmega328  pvs-studio  FAILED    00:00:00.016
======================================== 1 failed, 0 succeeded in 00:00:00.016 ========================================
```

I suggest there should be a quotation in the input and output file paths.