### PR TITLE
Create main.c instead of main.cpp for STSTM8

### DIFF
--- a/platformio/commands/home/rpc/handlers/project.py
+++ b/platformio/commands/home/rpc/handlers/project.py
@@ -215,7 +215,7 @@ class ProjectRPC:
             "ststm8",
         ]
         arduino_core_implementation_in_c = platform in platforms_with_arduino_c_implementation
-        main_source_file = "main.cpp" if not arduino_core_implementation_in_c else "main.c"
+        main_source_file = "main.c" if arduino_core_implementation_in_c else "main.cpp"
         main_content = None
         if framework == "arduino":
             main_content = "\n".join(

--- a/platformio/commands/home/rpc/handlers/project.py
+++ b/platformio/commands/home/rpc/handlers/project.py
@@ -17,7 +17,6 @@ from __future__ import absolute_import
 import os
 import shutil
 import time
-import click
 
 from ajsonrpc.core import JSONRPC20DispatchException
 


### PR DESCRIPTION
See issue #3872. 

Automatically creates a `main.c` instead of `main.cpp` for the STM8 platform.  

Without this, compilation just fails. This out-of-the-box failure has indeed put people off of using PlatformIO with STM8 as can be seen in e.g. https://youtu.be/mBwTsFBVuQo?t=434. 

Tested in VSCode by giving it a custom path in the extension options.

Also solves internal errors that the PIO extension throws after creating a STM8 Arduino project in the debug console

```
PIO Core Call Error: "The current working directory C:\\Users\\Max\\Documents\\PlatformIO\\Projects\\dummy_test3 will be used for the project.\r\n\r\nThe next files/directories have been created in C:\\Users\\Max\\Documents\\PlatformIO\\Projects\\dummy_test3\r\ninclude - Put project header files here\r\nlib - Put here project specific (private) libraries\r\nsrc - Put project source files here\r\nplatformio.ini - Project Configuration File\r\n\n\nError: Processing stm8sblue (platform: ststm8; board: stm8sblue; framework: arduino)\r\n--------------------------------------------------------------------------------\r\nVerbose mode can be enabled via `-v, --verbose` option\r\nCONFIGURATION: https://docs.platformio.org/page/boards/ststm8/stm8sblue.html\r\nPLATFORM: ST STM8 (2.0.0) > ST STM8S103F3 Breakout Board\r\nHARDWARE: STM8S103F3P6 16MHz, 1KB RAM, 8KB Flash\r\nDEBUG: Current (stlink) External (stlink)\r\nPACKAGES: \r\n - framework-arduinoststm8 0.50.210317 \r\n - tool-stm8binutils 0.230.0 (2.30) \r\n - toolchain-sdcc 1.30901.11242 (3.9.1)\r\nError: Detected C++ file `C:\\Users\\Max\\Documents\\PlatformIO\\Projects\\dummy_test3\\src\\main.cpp` which is not compatible with Arduino framework as only C/ASM sources are allowed.\r\n========================== [FAILED] Took 1.06 seconds =========================="
```