### PR TITLE
Bump zeroconf to 0.32

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ minimal_requirements = [
 ]
 
 if not PY2:
-    minimal_requirements.append("zeroconf==0.31.*")
+    minimal_requirements.append("zeroconf==0.32.*")
 
 home_requirements = [
     "aiofiles==0.7.*",


### PR DESCRIPTION
The [`zeroconf`](https://github.com/jstasiak/python-zeroconf) package has been upgraded to 0.32.0 recently with some bugfixes, nice work on better compliance with RFCs, and asyncio support.

Changelog: https://github.com/jstasiak/python-zeroconf#0320

Tested using: `pio device list --mdns` and quite a few mDNS-enabled devices on the network; no difference before/after upgrade