### PR TITLE
Feature/azure devops default prefix

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,3 +19,16 @@ To get started, <a href="https://cla-assistant.io/platformio/platformio-core">si
 9. Build documentation `tox -e docs` (creates a directory _build under docs where you can find the html)
 10. Commit changes to your forked repository
 11. Submit a Pull Request on GitHub.
+
+## Debugging in the IDE
+
+### PyCharm
+
+After running `tox` as above:
+
+1. In the Python Interpreter settings, add the Python interpreter that was installed with `tox`
+   with
+   
+       *Add > Virtualenv Environment > Existing Environment*
+   
+1. Add a Run Configuration with target “Module name” (not “Script path”) and value `platformio`

--- a/platformio/package/manager/_install.py
+++ b/platformio/package/manager/_install.py
@@ -14,6 +14,7 @@
 
 import hashlib
 import os
+import re
 import shutil
 import tempfile
 
@@ -125,6 +126,12 @@ class PackageManagerInstallMixin(object):
         spec = self.ensure_spec(spec)
         tmp_dir = tempfile.mkdtemp(prefix="pkg-installing-", dir=self.get_tmp_dir())
         vcs = None
+
+        azure_devops_re = re.compile(r'^https://[^/]+dev\.azure\.com/.*/_git/.+$')
+        if azure_devops_re.match(url):
+            url = "git+" + url
+            click.echo(f"Detected Azure DevOps URL: Using git+https URL {url}")
+
         try:
             if url.startswith("file://"):
                 _url = url[7:]


### PR DESCRIPTION
When cloning from Azure DevOps with the HTTPS URL copied from the *clone* tab, installation fails because PlatformIO downloads the HTML file instead of using the HTTPS protocol.

This PR prefixes Azure DevOps URLs with `+git`.