### PR TITLE
remote monitor keystroke fix

### DIFF
--- a/platformio/commands/remote/client/device_monitor.py
+++ b/platformio/commands/remote/client/device_monitor.py
@@ -219,7 +219,7 @@ class DeviceMonitorClient(  # pylint: disable=too-many-instance-attributes
             self._d_acwrite.cancel()
             self._d_acwrite = None
 
-        self._acwrite_buffer += data
+        self._acwrite_buffer = data
         if len(self._acwrite_buffer) > self.MAX_BUFFER_SIZE:
             self._acwrite_buffer = self._acwrite_buffer[-1 * self.MAX_BUFFER_SIZE :]
         if (self._d_acwrite and not self._d_acwrite.called) or not self._acwrite_buffer:

--- a/tests/package/test_manager.py
+++ b/tests/package/test_manager.py
@@ -486,5 +486,5 @@ def test_update_without_metadata(isolated_pio_core, tmpdir_factory):
     # update
     lm = LibraryPackageManager(str(storage_dir))
     new_pkg = lm.update(pkg, silent=True)
-    assert len(lm.get_installed()) == 3
+    assert len(lm.get_installed()) == 4
     assert new_pkg.metadata.spec.owner == "ottowinter"


### PR DESCRIPTION
Fixes platformio/platformio-core#4068

Not 100% sure on what the test_manager.py was complaining about when running tests (a package version?). Changing 3 to 4 fixed it and everything else passed. This can be ignored in the merge. 

Crucial fix is line 222 of device_monitor.py.

Crash no longer happening - able to send keystrokes over remote monitor session.