### PR TITLE
Add "inc" as sign that it's the root of the library

### DIFF
--- a/platformio/package/manager/library.py
+++ b/platformio/package/manager/library.py
@@ -62,7 +62,7 @@ class LibraryPackageManager(BasePackageManager):  # pylint: disable=too-many-anc
 
     @staticmethod
     def find_library_root(path):
-        root_dir_signs = set(["include", "Include", "src", "Src"])
+        root_dir_signs = set(["inc", "include", "Include", "src", "Src"])
         root_file_signs = set(
             [
                 "conanfile.py",  # Conan-based library

--- a/platformio/package/manager/library.py
+++ b/platformio/package/manager/library.py
@@ -62,7 +62,7 @@ class LibraryPackageManager(BasePackageManager):  # pylint: disable=too-many-anc
 
     @staticmethod
     def find_library_root(path):
-        root_dir_signs = set(["inc", "include", "Include", "src", "Src"])
+        root_dir_signs = set(["include", "Include", "inc", "Inc", "src", "Src"])
         root_file_signs = set(
             [
                 "conanfile.py",  # Conan-based library


### PR DESCRIPTION
Extends the list of folder names which PlatformIO detects as root folder in case there is no library manifests by the element "inc". 

Would fix the issue described in https://community.platformio.org/t/wrong-install-by-git-link-of-lib-without-manifest/24228.