### PR TITLE
Fix network storage build support on windows

### DIFF
--- a/platformio/package/manager/base.py
+++ b/platformio/package/manager/base.py
@@ -252,9 +252,9 @@ class BasePackageManager(  # pylint: disable=too-many-public-methods
         # external "URL" mismatch
         if spec.external:
             # local folder mismatch
-            if os.path.realpath(spec.url) == os.path.realpath(pkg.path) or (
+            if os.path.abspath(spec.url) == os.path.abspath(pkg.path) or (
                 spec.url.startswith("file://")
-                and os.path.realpath(pkg.path) == os.path.realpath(spec.url[7:])
+                and os.path.abspath(pkg.path) == os.path.abspath(spec.url[7:])
             ):
                 return True
             if spec.url != pkg.metadata.spec.url:


### PR DESCRIPTION
realpath and abspath are only interchangable on unix OS's. 

abspath returns a normalized absolutized version of the pathname, whereas realpath just parses through symbolic links to paths.

This breaks when \\networkpath\work is mapped to X: or any other drive letter on windows but as all paths work the same under all unix based OS's, it is unaffected.