### PR TITLE
Update util.py

### DIFF
--- a/platformio/util.py
+++ b/platformio/util.py
@@ -92,8 +92,6 @@ def singleton(cls):
 def get_systype():
     type_ = platform.system().lower()
     arch = platform.machine().lower()
-    if type_ == "windows":
-        arch = "amd64" if platform.architecture()[0] == "64bit" else "x86"
     return "%s_%s" % (type_, arch) if arch else type_
 
 


### PR DESCRIPTION
Fix error with incorrect determination OS version on win 64.  Fix for https://github.com/platformio/platform-ststm8/issues/50
Моre info:
>>> platform.machine().lower()
'amd64'
>>> platform.architecture() # return information about  Python executable not about OS
('32bit', 'WindowsPE')