### PR TITLE
_internet_on: try IPv4, if not acceptable — try IPv6

### DIFF
--- a/platformio/clients/http.py
+++ b/platformio/clients/http.py
@@ -196,16 +196,9 @@ def _internet_on():
                     continue
                 requests.get("http://%s" % host, allow_redirects=False, timeout=timeout)
                 return True
-            try:
-                # Try IPv4 connection:
-                s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-                s.connect((host, 80))
-            except OSError:
-                # On IPv6-only machine, previous request fail with "[Errno 101] Network is unreachable"
-                s = None
-                # Try IPv6 connection:
-                s = socket.socket(socket.AF_INET6, socket.SOCK_STREAM)
-                s.connect((host, 80))
+            # try to resolve `host` for both AF_INET and AF_INET6, and then try to connect
+            # to all possible addresses (IPv4 and IPv6) in turn until a connection succeeds:
+            s = socket.create_connection((host, 80))
             s.close()
             return True
         except:  # pylint: disable=bare-except

--- a/platformio/clients/http.py
+++ b/platformio/clients/http.py
@@ -196,8 +196,16 @@ def _internet_on():
                     continue
                 requests.get("http://%s" % host, allow_redirects=False, timeout=timeout)
                 return True
-            s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-            s.connect((host, 80))
+            try:
+                # Try IPv4 connection:
+                s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+                s.connect((host, 80))
+            except OSError:
+                # On IPv6-only machine, previous request fail with "[Errno 101] Network is unreachable"
+                s = None
+                # Try IPv6 connection:
+                s = socket.socket(socket.AF_INET6, socket.SOCK_STREAM)
+                s.connect((host, 80))
             s.close()
             return True
         except:  # pylint: disable=bare-except


### PR DESCRIPTION
Hello!

Thank you for this great project!

I use IPv6-only workstation with Gentoo GNU/Linux. To connect to IPv4-only resources, I use public services NAT64 + DNS64.

All the software works fine, except PlatformIO:

```
 % pio update --dry-run

Platform Manager
================
Platform gd32v
--------
Checking platformio/gd32v                     1.2.1                              [Off-line]
Checking platformio/framework-gd32vf103-sdk   1.0.0 @ ~1.0.0                     [Off-line]
Checking platformio/tool-openocd-gd32v        0.1.1 @ ~0.1.1                     [Off-line]
Checking platformio/tool-gd32vflash           0.1.0 @ ~0.1.0                     [Off-line]
Checking platformio/toolchain-gd32v           9.2.0 @ ~9.2.0                     [Off-line]
Checking platformio/tool-dfuutil              1.9.200310 @ ~1.9.200310           [Off-line]


Library Manager
===============
Library Storage: /home/user/.platformio/lib
Failed to check for PlatformIO upgrades. Please check your Internet connection.
```

I found function `_internet_on()` uses IPv4-only code `s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)`. The next command, `s.connect((host, 80))`, raises an error "[Errno 101] Network is unreachable" in my OS.

Then I found official documentation https://docs.python.org/3/library/socket.html, there are examples "… The next two examples are identical to the above two, but support both IPv4 and IPv6. …". I found these examples a bit complicated to integrate into PlatformIO (but you can create your own, **better solution**, based on official Python examples).

I created a patch, which works fine: if IPv4 is not available, try IPv6. Here is an example:

```
 % pio --version
PlatformIO Core, version 5.2.4

 % pio update

Platform Manager
================
Platform gd32v
--------
Updating platformio/gd32v                     1.2.1                              [Up-to-date]
Updating platformio/framework-gd32vf103-sdk   1.0.0 @ ~1.0.0                     [Up-to-date]
Updating platformio/tool-openocd-gd32v        0.1.1 @ ~0.1.1                     [Up-to-date]
Updating platformio/tool-gd32vflash           0.1.0 @ ~0.1.0                     [Up-to-date]
Updating platformio/toolchain-gd32v           9.2.0 @ ~9.2.0                     [Up-to-date]
Updating platformio/tool-dfuutil              1.9.200310 @ ~1.9.200310           [Up-to-date]


Library Manager
===============
Library Storage: /home/user/.platformio/lib
```

P.S.: maybe it is better to try first IPv6, and then IPv4, so IPv4 users will have good error message. But right now, as I understand, PlatformIO doesn't show error message, so this is doesn't matter.