### PR TITLE
Fixed wrong path

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -12,7 +12,8 @@ PlatformIO Core 5
 ~~~~~~~~~~~~~~~~~~
 
 - Improved support for private packages in `PlatformIO Registry <https://registry.platformio.org/>`__
-- Improved checking of available Internet connection for IPv6-only workstations (`pull #4151 <https://github.com/platformio/platformio-core/issues/4151>`_)
+- Improved checking of available Internet connection for IPv6-only workstations (`pull #4151 <https://github.com/platformio/platformio-core/pull/4151>`_)
+- Better detecting of default PlatformIO project directory on Linux OS (`pull #4158 <https://github.com/platformio/platformio-core/pull/4158>`_)
 - Respect disabling debugging server from "platformio.ini" passing an empty value to the `debug_server <https://docs.platformio.org/en/latest/projectconf/section_env_debug.html#debug-server>`__ option
 
 5.2.4 (2021-12-15)

--- a/platformio/project/helpers.py
+++ b/platformio/project/helpers.py
@@ -66,7 +66,7 @@ def get_project_cache_dir():
 
 
 def get_default_projects_dir():
-    docs_dir = os.path.join(fs.expanduser("~"), "Documents")
+    docs_dir = ""
     try:
         assert IS_WINDOWS
         import ctypes.wintypes  # pylint: disable=import-outside-toplevel
@@ -75,6 +75,10 @@ def get_default_projects_dir():
         ctypes.windll.shell32.SHGetFolderPathW(None, 5, None, 0, buf)
         docs_dir = buf.value
     except:  # pylint: disable=bare-except
+        try:
+            docs_dir = subprocess.check_output(['xdg-user-dir', 'DOCUMENTS']).decode('utf-8')
+        except FileNotFoundError: # command not found
+            docs_dir = os.path.join(fs.expanduser("~"), "Documents")
         pass
     return os.path.join(docs_dir, "PlatformIO", "Projects")
 


### PR DESCRIPTION
On linux, "Documents" doesn't have to be the right folder. It depends on the language selected when installing the operating system.

This PR addresses #4156 