### PR TITLE
Added udev rule for FireBeetle-ESP32.

### DIFF
--- a/scripts/99-platformio-udev.rules
+++ b/scripts/99-platformio-udev.rules
@@ -70,6 +70,9 @@ ATTRS{idVendor}=="0451", ATTRS{idProduct}=="f432", MODE="0666", ENV{ID_MM_DEVICE
 #GD32V DFU Bootloader
 ATTRS{idVendor}=="28e9", ATTRS{idProduct}=="0189", MODE="0666", ENV{ID_MM_DEVICE_IGNORE}="1", ENV{ID_MM_PORT_IGNORE}="1"
 
+# FireBeetle-ESP32
+ATTRS{idVendor}=="1a86", ATTRS{idProduct}=="7522", MODE="0666", ENV{ID_MM_DEVICE_IGNORE}="1", ENV{ID_MM_PORT_IGNORE}="1"
+
 #
 # Debuggers
 #


### PR DESCRIPTION
Fixes #4167.