### PR TITLE
Removing inconsistent dot at README.rst, HISTORY.rst and CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,7 +3,7 @@ Contributing
 
 To get started, <a href="https://cla-assistant.io/platformio/platformio-core">sign the Contributor License Agreement</a>.
 
-1. Fork the repository on GitHub.
+1. Fork the repository on GitHub
 2. Clone repository `git clone --recursive https://github.com/YourGithubUsername/platformio-core.git`
 3. Run `pip install tox`
 4. Go to the root of project where is located `tox.ini` and run `tox -e py37`
@@ -18,4 +18,4 @@ To get started, <a href="https://cla-assistant.io/platformio/platformio-core">si
 8. Run the tests `make test`
 9. Build documentation `tox -e docs` (creates a directory _build under docs where you can find the html)
 10. Commit changes to your forked repository
-11. Submit a Pull Request on GitHub.
+11. Submit a Pull Request on GitHub

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -297,7 +297,7 @@ Please check `Migration guide from 4.x to 5.0 <https://docs.platformio.org/en/la
   - Remove unused data using a new `pio system prune <https://docs.platformio.org/en/latest/core/userguide/system/cmd_prune.html>`__ command (`issue #3522 <https://github.com/platformio/platformio-core/issues/3522>`_)
   - Show ignored project environments only in the verbose mode (`issue #3641 <https://github.com/platformio/platformio-core/issues/3641>`_)
   - Do not escape compiler arguments in VSCode template on Windows
-  - Drop support for Python 2 and 3.5.
+  - Drop support for Python 2 and 3.5
 
 .. _release_notes_4:
 

--- a/README.rst
+++ b/README.rst
@@ -44,7 +44,7 @@ PlatformIO Core
 * Cross-platform IDE and Unified Debugger
 * Static Code Analyzer and Remote Unit Testing
 * Multi-platform and Multi-architecture Build System
-* Firmware File Explorer and Memory Inspection.
+* Firmware File Explorer and Memory Inspection
 
 Get Started
 -----------


### PR DESCRIPTION
It's just a little change, but at the some lists there is a dot at the last point, that is inconsistent.

The dot at the README.rst:
```diff
- * Firmware File Explorer and Memory Inspection.
+ * Firmware File Explorer and Memory Inspection
``` 

There is also an inconsistent dot at HISTORY.rst:
```diff
-  - Drop support for Python 2 and 3.5.
+  - Drop support for Python 2 and 3.5
```

The same for CONTRIBUTING.md:
```diff
- 1. Fork the repository on GitHub.
+ 1. Fork the repository on GitHub
- 11. Submit a Pull Request on GitHub.
+ 11. Submit a Pull Request on GitHub
```