### PR TITLE
Don't append --checks=* when the --config or --config-file flags are set

### DIFF
--- a/platformio/commands/check/tools/clangtidy.py
+++ b/platformio/commands/check/tools/clangtidy.py
@@ -60,7 +60,9 @@ class ClangtidyCheckTool(CheckToolBase):
 
         cmd = [tool_path, "--quiet"]
         flags = self.get_flags("clangtidy")
-        if not self.is_flag_set("--checks", flags):
+        if not (
+            self.is_flag_set("--checks", flags) or self.is_flag_set("--config", flags)
+        ):
             cmd.append("--checks=*")
 
         project_files = self.get_project_target_files(self.options["patterns"])


### PR DESCRIPTION
Fixes #4186

Appending --checks=* causes clang-tidy to ignore the flags --config and --config-file from `check_flags`, which breaks the ability to use a clang-tidy file. 