### PR TITLE
Avoid working with detached / non-existent git branches when checking for updates

### DIFF
--- a/platformio/package/manager/_update.py
+++ b/platformio/package/manager/_update.py
@@ -72,9 +72,14 @@ class PackageManagerUpdateMixin(object):
             return None
         if not vcs.can_be_updated:
             return None
+
+        vcs_revision = vcs.get_latest_revision()
+        if not vcs_revision:
+            return None
+
         return str(
             self.build_metadata(
-                pkg.path, pkg.metadata.spec, vcs_revision=vcs.get_latest_revision()
+                pkg.path, pkg.metadata.spec, vcs_revision=vcs_revision
             ).version
         )
 

--- a/platformio/package/vcsclient.py
+++ b/platformio/package/vcsclient.py
@@ -217,12 +217,17 @@ class GitClient(VCSClientBase):
             return self.get_current_revision()
         branch = self.get_current_branch()
         if not branch:
-            return self.get_current_revision()
-        result = self.get_cmd_output(["ls-remote"])
-        for line in result.split("\n"):
-            ref_pos = line.strip().find("refs/heads/" + branch)
-            if ref_pos > 0:
-                return line[:ref_pos].strip()[:7]
+            return None
+
+        branch_ref = f"refs/heads/{branch}"
+        result = self.get_cmd_output(["ls-remote", self.remote_url, branch_ref])
+
+        if result:
+            for line in result.split("\n"):
+                sha, ref = line.split("\t")
+                if ref == branch_ref:
+                    return sha[:7]
+
         return None
 
 

--- a/platformio/package/vcsclient.py
+++ b/platformio/package/vcsclient.py
@@ -221,12 +221,13 @@ class GitClient(VCSClientBase):
 
         branch_ref = f"refs/heads/{branch}"
         result = self.get_cmd_output(["ls-remote", self.remote_url, branch_ref])
+        if not result:
+            return None
 
-        if result:
-            for line in result.split("\n"):
-                sha, ref = line.split("\t")
-                if ref == branch_ref:
-                    return sha[:7]
+        for line in result.split("\n"):
+            sha, ref = line.strip().split("\t")
+            if ref == branch_ref:
+                return sha[:7]
 
         return None
 


### PR DESCRIPTION
b/c we can't use `pull` anyway in that situation
also ask *only* for the specific branch via `refs/heads/{branch}` and fail when it is not available. `pkg update` / `pkg outdated` will not do or display anything if that's the case.

resolves #4139 
(and I am not familiar with the svn & hg cases, so only git implementation was changed)