### PR TITLE
Add CI workflow for popular PlatformIO projects

### DIFF
--- a/.github/workflows/projects.yml
+++ b/.github/workflows/projects.yml
@@ -37,19 +37,17 @@ jobs:
 
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           submodules: "recursive"
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v3
         with:
           python-version: 3.9
 
       - name: Install PlatformIO
-        run: |
-          python -m pip install --upgrade pip
-          pip install .
+        run: pip install -U .
 
       - name: Check out ${{ matrix.project.repository }}
         uses: actions/checkout@v2

--- a/.github/workflows/projects.yml
+++ b/.github/workflows/projects.yml
@@ -1,11 +1,6 @@
 name: Projects
 
-on:
-  push:
-    branches:
-      - release/*
-      - project*
-      - feature/project*
+on: [push, pull_request]
 
 jobs:
   build:

--- a/.github/workflows/projects.yml
+++ b/.github/workflows/projects.yml
@@ -12,7 +12,7 @@ jobs:
             repository: "MarlinFirmware/Marlin"
             folder: "Marlin"
             config_dir: "Marlin"
-            env_name: "teensy36"
+            env_name: "mega2560"
           - esphome:
             repository: "esphome/esphome"
             folder: "esphome"
@@ -59,19 +59,11 @@ jobs:
           repository: ${{ matrix.project.repository }}
           path: ${{ matrix.project.folder }}
 
-      - name: Configure Marlin target
-        # The board is selected in the 'Configuration.h' file. Currently, there is no
-        # way to pass the board via a build flag (e.g. -D) as there is a prescript that
-        # carries out some validations before the build step
-        if: ${{ contains(matrix.project.repository, 'Marlin') }}
-        run: sed -i 's/#define MOTHERBOARD BOARD_RAMPS_14_EFB/#define MOTHERBOARD BOARD_TEENSY35_36/g' ${{ matrix.project.folder }}/Marlin/Configuration.h
-
       - name: Install ESPHome dependencies
         # Requires esptool package as it's used in a custom prescript
         if: ${{ contains(matrix.project.repository, 'esphome') }}
         run: pip install esptool==3.*
 
       - name: Compile ${{ matrix.project.repository }}
-        run: |
-          pio run -d ${{ matrix.project.config_dir }} -e ${{ matrix.project.env_name }}
+        run: pio run -d ${{ matrix.project.config_dir }} -e ${{ matrix.project.env_name }}
 

--- a/.github/workflows/projects.yml
+++ b/.github/workflows/projects.yml
@@ -33,9 +33,8 @@ jobs:
             folder: "OpenMQTTGateway"
             config_dir: "OpenMQTTGateway"
             env_name: "esp32-m5atom"
-        os: [ubuntu-latest]
-        # Note: espurna doesn't work with Python 3.6
-        python-version: ["3.7", "3.8", "3.9", "3.10"]
+        os: [ubuntu-latest, windows-latest, macos-latest]
+
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2
@@ -45,7 +44,7 @@ jobs:
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v2
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: 3.9
 
       - name: Install PlatformIO
         run: |

--- a/.github/workflows/projects.yml
+++ b/.github/workflows/projects.yml
@@ -1,0 +1,82 @@
+name: Projects
+
+on:
+  push:
+    branches:
+      - release/*
+      - project*
+      - feature/project*
+
+jobs:
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        project:
+          - marlin:
+            repository: "MarlinFirmware/Marlin"
+            folder: "Marlin"
+            config_dir: "Marlin"
+            env_name: "teensy36"
+          - esphome:
+            repository: "esphome/esphome"
+            folder: "esphome"
+            config_dir: "esphome"
+            env_name: "esp32-arduino"
+          - smartknob:
+            repository: "scottbez1/smartknob"
+            folder: "smartknob"
+            config_dir: "smartknob/firmware"
+            env_name: "view"
+          - espurna:
+            repository: "xoseperez/espurna"
+            folder: "espurna"
+            config_dir: "espurna/code"
+            env_name: "nodemcu-lolin"
+          - OpenMQTTGateway:
+            repository: "1technophile/OpenMQTTGateway"
+            folder: "OpenMQTTGateway"
+            config_dir: "OpenMQTTGateway"
+            env_name: "esp32-m5atom"
+        os: [ubuntu-latest]
+        # Note: espurna doesn't work with Python 3.6
+        python-version: ["3.7", "3.8", "3.9", "3.10"]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: "recursive"
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install PlatformIO
+        run: |
+          python -m pip install --upgrade pip
+          pip install .
+
+      - name: Check out ${{ matrix.project.repository }}
+        uses: actions/checkout@v2
+        with:
+          submodules: "recursive"
+          repository: ${{ matrix.project.repository }}
+          path: ${{ matrix.project.folder }}
+
+      - name: Configure Marlin target
+        # The board is selected in the 'Configuration.h' file. Currently, there is no
+        # way to pass the board via a build flag (e.g. -D) as there is a prescript that
+        # carries out some validations before the build step
+        if: ${{ contains(matrix.project.repository, 'Marlin') }}
+        run: sed -i 's/#define MOTHERBOARD BOARD_RAMPS_14_EFB/#define MOTHERBOARD BOARD_TEENSY35_36/g' ${{ matrix.project.folder }}/Marlin/Configuration.h
+
+      - name: Install ESPHome dependencies
+        # Requires esptool package as it's used in a custom prescript
+        if: ${{ contains(matrix.project.repository, 'esphome') }}
+        run: pip install esptool==3.*
+
+      - name: Compile ${{ matrix.project.repository }}
+        run: |
+          pio run -d ${{ matrix.project.config_dir }} -e ${{ matrix.project.env_name }}
+


### PR DESCRIPTION
This PR adds a new CI workflow that should catch basic regressions to safeguard the most popular projects that rely on PlatformIO. The following projects are checked:

- [MarlinFirmware/Marlin](https://github.com/MarlinFirmware/Marlin)
- [esphome/esphome](https://github.com/esphome/esphome)
- [scottbez1/smartknob](https://github.com/scottbez1/smartknob)
- [xoseperez/espurna](https://github.com/xoseperez/espurna)
- [1technophile/OpenMQTTGateway](https://github.com/1technophile/OpenMQTTGateway)

Note that the CI will be run only on PUSH events in the `release/*` and `project*` branches. 
