### PR TITLE
Fix filter argument used in remote agent

### DIFF
--- a/platformio/commands/remote/client/agent_service.py
+++ b/platformio/commands/remote/client/agent_service.py
@@ -172,6 +172,8 @@ class RemoteAgentService(RemoteClientBase):
             cmd_args.extend(["-e", env])
         for target in options.get("target", []):
             cmd_args.extend(["-t", target])
+        for filter in options.get("filter", []):
+            cmd_args.extend(["-f", filter])
         for ignore in options.get("ignore", []):
             cmd_args.extend(["-i", ignore])
         if options.get("upload_port", False):

--- a/platformio/commands/remote/client/agent_service.py
+++ b/platformio/commands/remote/client/agent_service.py
@@ -172,8 +172,8 @@ class RemoteAgentService(RemoteClientBase):
             cmd_args.extend(["-e", env])
         for target in options.get("target", []):
             cmd_args.extend(["-t", target])
-        for _filter in options.get("filter", []):
-            cmd_args.extend(["-f", _filter])
+        for filter_ in options.get("filter", []):
+            cmd_args.extend(["-f", filter_])
         for ignore in options.get("ignore", []):
             cmd_args.extend(["-i", ignore])
         if options.get("upload_port", False):

--- a/platformio/commands/remote/client/agent_service.py
+++ b/platformio/commands/remote/client/agent_service.py
@@ -135,7 +135,7 @@ class RemoteAgentService(RemoteClientBase):
     def _process_cmd_test(self, options):
         return self._process_cmd_run_or_test("test", options)
 
-    def _process_cmd_run_or_test(  # pylint: disable=too-many-locals,too-many-branches
+    def _process_cmd_run_or_test(  # pylint: disable=too-many-locals,too-many-branches,too-many-statements
         self, command, options
     ):
         assert options and "project_id" in options
@@ -172,8 +172,8 @@ class RemoteAgentService(RemoteClientBase):
             cmd_args.extend(["-e", env])
         for target in options.get("target", []):
             cmd_args.extend(["-t", target])
-        for filter in options.get("filter", []):
-            cmd_args.extend(["-f", filter])
+        for _filter in options.get("filter", []):
+            cmd_args.extend(["-f", _filter])
         for ignore in options.get("ignore", []):
             cmd_args.extend(["-i", ignore])
         if options.get("upload_port", False):


### PR DESCRIPTION
filter argument is being sent to remote agent, but is not being used.
This will fix these kind of commands:

```
platformio remote test -e xx -f test_xx
```

related issue #4204