### PR TITLE
Append files from any folder in src_dir starting with ino_ too

### DIFF
--- a/platformio/builder/tools/pioino.py
+++ b/platformio/builder/tools/pioino.py
@@ -230,6 +230,10 @@ def ConvertInoToCpp(env):
     ino_nodes = env.Glob(os.path.join(src_dir, "*.ino")) + env.Glob(
         os.path.join(src_dir, "*.pde")
     )
+    # append files from any folder in src_dir starting with ino_ too
+    ino_nodes = ino_nodes + env.Glob(os.path.join(src_dir, "ino_*", "*.ino")) + env.Glob(
+        os.path.join(src_dir, "ino_*", "*.pde")
+    )
     if not ino_nodes:
         return
     c = InoToCPPConverter(env)


### PR DESCRIPTION
This allows for moving files from the root to sub-folders like moving all sensor drivers to one folder called ino_xsns and other drivers to a folder called ino_xdrv. The naming is still important as the InoToCpp conversion needs files in alphabetical order.

I've tested this with Tasmota andmoving the drivers into 6 different folders.