### PR TITLE
docs: Fix a few typos

### DIFF
--- a/platformio/test/helpers.py
+++ b/platformio/test/helpers.py
@@ -43,7 +43,7 @@ def list_test_suites(project_config, environments, filters, ignores):
             # filter and ignore patterns
             patterns = dict(filter=list(filters), ignore=list(ignores))
             for key, value in patterns.items():
-                if value:  # overriden from CLI
+                if value:  # overridden from CLI
                     continue
                 patterns[key].extend(  # pylint: disable=unnecessary-dict-index-lookup
                     project_config.get(f"env:{env_name}", f"test_{key}", [])

--- a/platformio/util.py
+++ b/platformio/util.py
@@ -34,7 +34,7 @@ from platformio.proc import exec_command
 # pylint: enable=unused-import
 
 # also export list_serial_ports as get_serialports to be
-# backward compatiblty with arduinosam versions 3.9.0 to 3.5.0 (and possibly others)
+# backward compatibility with arduinosam versions 3.9.0 to 3.5.0 (and possibly others)
 get_serialports = get_serial_ports
 
 

--- a/tests/project/test_savedeps.py
+++ b/tests/project/test_savedeps.py
@@ -54,7 +54,7 @@ def test_save_libraries(tmp_path):
         PackageSpec("https://github.com/nanopb/nanopb.git"),
     ]
 
-    # add to the sepcified environment
+    # add to the specified environment
     save_project_dependencies(
         str(project_dir), specs, scope="lib_deps", action="add", environments=["debug"]
     )
@@ -140,7 +140,7 @@ def test_save_tools(tmp_path):
         PackageSpec("platformio/tool-esptoolpy"),
     ]
 
-    # add to the sepcified environment
+    # add to the specified environment
     save_project_dependencies(
         str(project_dir),
         specs,


### PR DESCRIPTION
There are small typos in:
- platformio/test/helpers.py
- platformio/util.py
- tests/project/test_savedeps.py

Fixes:
- Should read `specified` rather than `sepcified`.
- Should read `overridden` rather than `overriden`.
- Should read `compatibility` rather than `compatiblty`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md