### PR TITLE
fix compat mode when no framework

### DIFF
--- a/platformio/builder/tools/piolib.py
+++ b/platformio/builder/tools/piolib.py
@@ -1035,7 +1035,7 @@ def IsCompatibleLibBuilder(env, lb, verbose=int(ARGUMENTS.get("PIOVERBOSE", 0)))
             sys.stderr.write("Platform incompatible library %s\n" % lb.path)
         return False
     if compat_mode in ("soft", "strict") and not lb.is_frameworks_compatible(
-        env.get("PIOFRAMEWORK", [])
+        env.get("PIOFRAMEWORK", "__noframework__")
     ):
         if verbose:
             sys.stderr.write("Framework incompatible library %s\n" % lb.path)


### PR DESCRIPTION
In some situation when using 'native' platform then pio might treat some libraries as compatible even if lib_compat_mode=strict is used and it will then fail to compile arduino library under native platform.
As native does not contain any 'framework' then 'is_frameworks_compatible()' might treat library as compatible even if library.json says its for 'arduino' only for example
Untill now i used lib_ignore to overcome this issue but in long term its hassle to keep it updated
```
platformio.ini

[env:main_dev_SDL]
platform = native
; framework = none
; board = non
lib_compat_mode = strict ; do nothing in this case as is_frameworks_compatible() will be false positive when no framework defined

[env:main_dev]
platform = espressif32
framework = arduino
board = esp32dev
```


```
library.json

{
	"name": "spiDev",
	"frameworks": "arduino",
	"platforms": "*"
}
```


PS. im not very familiar with python but 'is_frameworks_compatible' look very strange with its 'frameworks=["arduino", "energia"]' especially compared to 'platforms=self._manifest.get("platforms")' for 'is_platforms_compatible'
```
    def is_frameworks_compatible(self, frameworks):
        return PackageCompatibility(frameworks=frameworks).is_compatible(
            PackageCompatibility(frameworks=["arduino", "energia"])
        )

    def is_platforms_compatible(self, platforms):
        return PackageCompatibility(platforms=platforms).is_compatible(
            PackageCompatibility(platforms=self._manifest.get("platforms"))
        )
```
