### PR TITLE
optionally pass env to AddBuildMiddleware callback

### DIFF
--- a/platformio/builder/tools/piobuild.py
+++ b/platformio/builder/tools/piobuild.py
@@ -292,7 +292,10 @@ def CollectBuildFiles(
         for callback, pattern in middlewares:
             if pattern and not fnmatch.fnmatch(node.srcnode().get_path(), pattern):
                 continue
-            new_node = callback(new_node)
+            if callback.__code__.co_argcount == 2:
+                new_node = callback(env, new_node)
+            else:
+                new_node = callback(new_node)
         if new_node:
             new_sources.append(new_node)
 


### PR DESCRIPTION
It appears `env` is not yet fully when the pre-script is ran (env vs projenv?), however when Build Middlewares are employed [as described](https://docs.platformio.org/en/stable//scripting/middlewares.html), this incomplete environment is used to construct the env.Object entries, leading to missing compiler arguments.

Similar problems are mentioned [here](https://community.platformio.org/t/addbuildmiddleware-missing-include-flags-i/23594)

This PR optionally, as to not break compatibility, passes the _current_ environment  to the callback, in-line with how its handled with [Pre & Post action callbacks](https://docs.platformio.org/en/stable//scripting/actions.html)

To reproduce the issue:

```python
def rewrite_source(node):
    return env.Object(node)

env.AddBuildMiddleware(rewrite_source)
```
leads to:
```
arm-none-eabi-gcc -o .pio/build/matekf405/src/config/profile.o -c -std=gnu11 -mfloat-abi=softfp -mfpu=fpv4-sp-d16 -s -O3 -flto -Wdouble-promotion -Wunsafe-loop-optimizations -fsingle-precision-constant -fno-exceptions -fno-strict-aliasing -fstack-usage -fno-stack-protector -fomit-frame-pointer -fno-unwind-tables -fno-asynchronous-unwind-tables -fno-math-errno -fmerge-all-constants -funsafe-loop-optimizations -mthumb -mcpu=cortex-m4 -ffunction-sections -fdata-sections -Wall -nostdlib
-DPLATFORMIO=60104 -DSTM32F40_41xxx -DSTM32F405xx -DSTM32F4xx -DSTM32F405 -DSTM32F4 -DMCU_NAME=stm32f405 -DHSE_VALUE=8000000U -DUSE_FAST_RAM -DUSBD_SOF_DISABLED -DUSE_FULL_LL_DRIVER -DHSE_STARTUP_TIMEOUT=5000 -DUSE_HAL_DRIVER -DF_CPU=168000000L
-Isrc -Isrc/rx -Isrc/osd -Isrc/config -Isrc/drivers -Isrc/system/stm32f405 -Isrc/targets/matekf405 -Isrc -Isrc -I/home/hanfer/.platformio/packages/framework-stm32cubef4/Drivers/CMSIS/Include -I/home/hanfer/.platformio/packages/framework-stm32cubef4/Drivers/CMSIS/Device/ST/STM32F4xx/Include -I/home/hanfer/.platformio/packages/framework-stm32cubef4/Drivers/STM32F4xx_HAL_Driver/Inc -I/home/hanfer/.platformio/packages/framework-stm32cubef4/Drivers/STM32F4xx_HAL_Driver/Src -I/home/hanfer/.platformio/packages/framework-stm32cubef4/Drivers/CMSIS/DSP/Include src/config/profile.c
```

Whereas: 
```python
def rewrite_source(node, localenv):
    return localenv.Object(node)

env.AddBuildMiddleware(rewrite_source)
```
leads to
```
arm-none-eabi-gcc -o .pio/build/matekf405/src/config/profile.o -c -std=gnu11 -mfloat-abi=softfp -mfpu=fpv4-sp-d16 -s -O3 -flto -Wdouble-promotion -Wunsafe-loop-optimizations -fsingle-precision-constant -fno-exceptions -fno-strict-aliasing -fstack-usage -fno-stack-protector -fomit-frame-pointer -fno-unwind-tables -fno-asynchronous-unwind-tables -fno-math-errno -fmerge-all-constants -funsafe-loop-optimizations -mthumb -mcpu=cortex-m4 -ffunction-sections -fdata-sections -Wall -nostdlib 
-DPLATFORMIO=60104 -DSTM32F40_41xxx -DSTM32F405xx -DSTM32F4xx -DSTM32F405 -DSTM32F4 -DMCU_NAME=stm32f405 -DHSE_VALUE=8000000U -DUSE_FAST_RAM -DUSBD_SOF_DISABLED -DUSE_FULL_LL_DRIVER -DHSE_STARTUP_TIMEOUT=5000 -DUSE_HAL_DRIVER -DF_CPU=168000000L -DTARGET=stm32f405 -DGIT_VERSION=d4d201d 
-Ilib/cbor/include -Ilib/cbor/src -Ilib/libusb_stm32/inc -Ilib/libusb_stm32/src -Isrc -Isrc/rx -Isrc/osd -Isrc/config -Isrc/drivers -Isrc/system/stm32f405 -Isrc/targets/matekf405 -Isrc -Isrc -I/home/hanfer/.platformio/packages/framework-stm32cubef4/Drivers/CMSIS/Include -I/home/hanfer/.platformio/packages/framework-stm32cubef4/Drivers/CMSIS/Device/ST/STM32F4xx/Include -I/home/hanfer/.platformio/packages/framework-stm32cubef4/Drivers/STM32F4xx_HAL_Driver/Inc -I/home/hanfer/.platformio/packages/framework-stm32cubef4/Drivers/STM32F4xx_HAL_Driver/Src -I/home/hanfer/.platformio/packages/framework-stm32cubef4/Drivers/CMSIS/DSP/Include src/config/profile.c
```
Take note of `-DTARGET` and the include dirs for `cbor` and `libusb_stm32`
