### PR TITLE
FIX  Unescaped File Path

### DIFF
--- a/tests/commands/test_run.py
+++ b/tests/commands/test_run.py
@@ -150,7 +150,7 @@ env.Append(CPPDEFINES=[("TMP_MACRO_4", 4)])
 env.Append(CCFLAGS=["-Os"])
 env.Append(LIBS=["unknownLib"])
     """
-        % str(tmpdir)
+        % str(tmpdir).replace("\\", "\\\\")
     )
 
     tmpdir.mkdir("src").join("main.c").write(


### PR DESCRIPTION
Fix Issue #4391 in platformio/platformio-core

https://github.com/platformio/platformio-core/issues/4391

Use Python string.replace(find, replace) method to escape backslash
`\` characters with a preceding backslash.

`C:\A\path\that\is.unescaped`

becomes

`C:\\A\\path\\that\\is.unescaped`

Preventing the '\t' from being interpreted as a special character.

It also prevents Python syntax errors from unrecognized ASCII encoding sequences.