### PR TITLE
make bash version check case insensitive

### DIFF
--- a/platformio/system/completion.py
+++ b/platformio/system/completion.py
@@ -30,7 +30,7 @@ class ShellType(Enum):
 
 def get_bash_version():
     result = subprocess.run(["bash", "--version"], capture_output=True, check=True)
-    match = re.search(r"version\s+(\d+)\.(\d+)", result.stdout.decode())
+    match = re.search(r"version\s+(\d+)\.(\d+)", result.stdout.decode(), re.IGNORECASE)
     if match:
         return (int(match.group(1)), int(match.group(2)))
     return (0, 0)


### PR DESCRIPTION
the output of `bash --version` is different when the system is configured for e.g. de_DE locale. For german locale the it's `GNU bash, Version 5.0…` with an uppercase 'V'. This makes the bash completion setup fail with the error `Error: The minimal supported Bash version is 4.4`.

To fix this, the version match regex now uses the `IGNORECASE` flag.