### PR TITLE
Add list_logical_devices to public

### DIFF
--- a/platformio/public.py
+++ b/platformio/public.py
@@ -14,7 +14,7 @@
 
 # pylint: disable=unused-import
 
-from platformio.device.list.util import list_serial_ports
+from platformio.device.list.util import list_serial_ports, list_logical_devices
 from platformio.device.monitor.filters.base import DeviceMonitorFilterBase
 from platformio.fs import to_unix_path
 from platformio.platform.base import PlatformBase

--- a/platformio/public.py
+++ b/platformio/public.py
@@ -14,7 +14,7 @@
 
 # pylint: disable=unused-import
 
-from platformio.device.list.util import list_serial_ports, list_logical_devices
+from platformio.device.list.util import list_logical_devices, list_serial_ports
 from platformio.device.monitor.filters.base import DeviceMonitorFilterBase
 from platformio.fs import to_unix_path
 from platformio.platform.base import PlatformBase


### PR DESCRIPTION
This would help platform developers ensure compatibility between versions. 
In short, I ran for hours after a changed import. 
I think this commit introduced this issue: https://github.com/platformio/platformio-core/commit/a6e61a7a5a24cf73d2866b9817e8b9a7e99852d0

This would save others from that: https://github.com/maxgerhardt/platform-raspberrypi/issues/15