### PR TITLE
Legacy docs urls changed to the current structure

### DIFF
--- a/platformio/__main__.py
+++ b/platformio/__main__.py
@@ -120,7 +120,7 @@ An unexpected error occurred. Further steps:
   `pip install -U platformio` command
 
 * Try to find answer in FAQ Troubleshooting section
-  https://docs.platformio.org/page/faq/index.html
+  https://docs.platformio.org/en/latest/faq/index.html
 
 * Report this problem to the developers
   https://github.com/platformio/platformio-core/issues

--- a/platformio/assets/templates/ide-projects/clion/CMakeLists.txt.tpl
+++ b/platformio/assets/templates/ide-projects/clion/CMakeLists.txt.tpl
@@ -1,5 +1,5 @@
 # !!! WARNING !!! AUTO-GENERATED FILE, PLEASE DO NOT MODIFY IT AND USE
-# https://docs.platformio.org/page/projectconf/section_env_build.html#build-flags
+# https://docs.platformio.org/en/latest/projectconf/section_env_build.html#build-flags
 #
 # If you need to override existing CMake configuration or add extra,
 # please create `CMakeListsUser.txt` in the root of project.

--- a/platformio/assets/templates/ide-projects/clion/CMakeListsPrivate.txt.tpl
+++ b/platformio/assets/templates/ide-projects/clion/CMakeListsPrivate.txt.tpl
@@ -1,5 +1,5 @@
 # !!! WARNING !!! AUTO-GENERATED FILE, PLEASE DO NOT MODIFY IT AND USE
-# https://docs.platformio.org/page/projectconf/section_env_build.html#build-flags
+# https://docs.platformio.org/en/latest/projectconf/section_env_build.html#build-flags
 #
 # If you need to override existing CMake configuration or add extra,
 # please create `CMakeListsUser.txt` in the root of project.

--- a/platformio/assets/templates/ide-projects/vscode/.vscode/c_cpp_properties.json.tpl
+++ b/platformio/assets/templates/ide-projects/vscode/.vscode/c_cpp_properties.json.tpl
@@ -86,7 +86,7 @@
 //
 // !!! WARNING !!! AUTO-GENERATED FILE!
 // PLEASE DO NOT MODIFY IT AND USE "platformio.ini":
-// https://docs.platformio.org/page/projectconf/section_env_build.html#build-flags
+// https://docs.platformio.org/en/latest/projectconf/section_env_build.html#build-flags
 //
 {
     "configurations": [

--- a/platformio/assets/templates/ide-projects/vscode/.vscode/launch.json.tpl
+++ b/platformio/assets/templates/ide-projects/vscode/.vscode/launch.json.tpl
@@ -93,7 +93,7 @@
 //
 // PIO Unified Debugger
 //
-// Documentation: https://docs.platformio.org/page/plus/debugging.html
-// Configuration: https://docs.platformio.org/page/projectconf/section_env_debug.html
+// Documentation: https://docs.platformio.org/en/latest/plus/debugging.html
+// Configuration: https://docs.platformio.org/en/latest/projectconf/section_env_debug.html
 
 {{ json.dumps(get_launch_configuration(), indent=4, ensure_ascii=False) }}

--- a/platformio/builder/tools/piolib.py
+++ b/platformio/builder/tools/piolib.py
@@ -1107,7 +1107,7 @@ def GetLibBuilders(_):  # pylint: disable=too-many-branches
     if verbose and found_incompat:
         sys.stderr.write(
             'More details about "Library Compatibility Mode": '
-            "https://docs.platformio.org/page/librarymanager/ldf.html#"
+            "https://docs.platformio.org/en/latest/librarymanager/ldf.html#"
             "ldf-compat-mode\n"
         )
 

--- a/platformio/builder/tools/pioplatform.py
+++ b/platformio/builder/tools/pioplatform.py
@@ -142,7 +142,7 @@ def PrintConfiguration(env):  # pylint: disable=too-many-statements
             if not board_config
             else [
                 "CONFIGURATION:",
-                "https://docs.platformio.org/page/boards/%s/%s.html"
+                "https://docs.platformio.org/en/latest/boards/%s/%s.html"
                 % (platform.name, board_config.id),
             ]
         )

--- a/platformio/debug/exception.py
+++ b/platformio/debug/exception.py
@@ -25,7 +25,7 @@ class DebugSupportError(DebugError, UserSideException):
         "Currently, PlatformIO does not support debugging for `{0}`.\n"
         "Please request support at https://github.com/platformio/"
         "platformio-core/issues \nor visit -> https://docs.platformio.org"
-        "/page/plus/debugging.html"
+        "/en/latest/plus/debugging.html"
     )
 
 

--- a/platformio/debug/process/server.py
+++ b/platformio/debug/process/server.py
@@ -57,7 +57,7 @@ class DebugServerProcess(DebugBaseProcess):
             raise DebugInvalidOptionsError(
                 "Could not launch Debug Server '%s'. Please check that it "
                 "is installed and is included in a system PATH\n"
-                "See https://docs.platformio.org/page/plus/debugging.html"
+                "See https://docs.platformio.org/en/latest/plus/debugging.html"
                 % server_executable
             )
 

--- a/platformio/exception.py
+++ b/platformio/exception.py
@@ -110,7 +110,7 @@ class UpgradeError(PlatformioException):
 
 * Upgrade using `pip install -U platformio`
 * Try different installation/upgrading steps:
-  https://docs.platformio.org/page/installation.html
+  https://docs.platformio.org/en/latest/core/installation/index.html
 """
 
 

--- a/platformio/package/exception.py
+++ b/platformio/package/exception.py
@@ -42,7 +42,7 @@ class ManifestValidationError(ManifestException):
     def __str__(self):
         return (
             "Invalid manifest fields: %s. \nPlease check specification -> "
-            "https://docs.platformio.org/page/librarymanager/config.html"
+            "https://docs.platformio.org/en/latest/manifests/library-json/index.html"
             % self.messages
         )
 

--- a/platformio/package/manager/core.py
+++ b/platformio/package/manager/core.py
@@ -179,7 +179,7 @@ def build_contrib_pysite_package(target_dir, with_metadata=True):
                 else systype,
                 description="Extra Python package for PlatformIO Core",
                 keywords=["platformio", "platformio-core"],
-                homepage="https://docs.platformio.org/page/core/index.html",
+                homepage="https://docs.platformio.org/en/latest/core/index.html",
                 repository={
                     "type": "git",
                     "url": "https://github.com/platformio/platformio-core",

--- a/platformio/project/commands/init.py
+++ b/platformio/project/commands/init.py
@@ -240,7 +240,7 @@ For example, see a structure of the following two libraries `Foo` and `Bar`:
 |  |  |--src
 |  |     |- Bar.c
 |  |     |- Bar.h
-|  |  |- library.json (optional, custom build options, etc) https://docs.platformio.org/page/librarymanager/config.html
+|  |  |- library.json (optional, custom build options, etc) https://docs.platformio.org/en/latest/manifests/library-json/index.html
 |  |
 |  |--Foo
 |  |  |- Foo.c
@@ -268,7 +268,7 @@ PlatformIO Library Dependency Finder will find automatically dependent
 libraries scanning project source files.
 
 More information about PlatformIO Library Dependency Finder
-- https://docs.platformio.org/page/librarymanager/ldf.html
+- https://docs.platformio.org/en/latest/librarymanager/ldf.html
 """,
         )
 

--- a/platformio/project/config.py
+++ b/platformio/project/config.py
@@ -34,7 +34,7 @@ CONFIG_HEADER = """
 ;   Advanced options: extra scripting
 ;
 ; Please visit documentation for the other options and examples
-; https://docs.platformio.org/page/projectconf.html
+; https://docs.platformio.org/en/latest/projectconf/index.html
 """
 
 

--- a/platformio/remote/client/base.py
+++ b/platformio/remote/client/base.py
@@ -185,7 +185,7 @@ class RemoteClientBase(  # pylint: disable=too-many-instance-attributes
             msg = (
                 "Could not find active agents. Please start it before on "
                 "a remote machine using `pio remote agent start` command.\n"
-                "See http://docs.platformio.org/page/plus/pio-remote.html"
+                "See https://docs.platformio.org/en/latest/plus/pio-remote.html"
             )
         else:
             maintenance.on_platformio_exception(Exception(err.type))

--- a/scripts/docspregen.py
+++ b/scripts/docspregen.py
@@ -1038,7 +1038,7 @@ def update_project_examples():
 {description}
 
 * [Home](https://platformio.org/platforms/{name}) (home page in PlatformIO Registry)
-* [Documentation](https://docs.platformio.org/page/platforms/{name}.html) (advanced usage, packages, boards, frameworks, etc.)
+* [Documentation](https://docs.platformio.org/en/latest/platforms/{name}.html) (advanced usage, packages, boards, frameworks, etc.)
 
 # Examples
 
@@ -1050,7 +1050,7 @@ def update_project_examples():
 {description}
 
 * [Home](https://platformio.org/frameworks/{name}) (home page in PlatformIO Registry)
-* [Documentation](https://docs.platformio.org/page/frameworks/{name}.html)
+* [Documentation](https://docs.platformio.org/en/latest/frameworks/{name}.html)
 
 # Examples
 


### PR DESCRIPTION
I just opened those URLs to see where they point right now.

* https://github.com/platformio/platformio-docs/issues/275#issuecomment-1329510718
* https://github.com/platformio/platformio-docs/pull/276