### PR TITLE
add udev rule for AIR32F103 board

### DIFF
--- a/platformio/assets/system/99-platformio-udev.rules
+++ b/platformio/assets/system/99-platformio-udev.rules
@@ -82,6 +82,9 @@ ATTRS{idVendor}=="2886", ATTRS{idProduct}=="[08]02d", MODE="0666", ENV{ID_MM_DEV
 # Raspberry Pi Pico
 ATTRS{idVendor}=="2e8a", ATTRS{idProduct}=="[01]*", MODE:="0666", ENV{ID_MM_DEVICE_IGNORE}="1", ENV{ID_MM_PORT_IGNORE}="1"
 
+# AIR32F103
+ATTRS{idVendor}=="0d28", ATTRS{idProduct}=="0204", MODE="0666", ENV{ID_MM_DEVICE_IGNORE}="1", ENV{ID_MM_PORT_IGNORE}="1"
+
 
 #
 # Debuggers


### PR DESCRIPTION
It's a low cost dev board that can use as DAPLink debugger. [info](https://wiki.luatos.com/chips/air32f103/board.html)  
This PR fixed `Error: unable to open CMSIS-DAP device 0xd28:0x204` while running upload task.