### PR TITLE
Introduce a centralized GHA check/gate job

### DIFF
--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -45,3 +45,18 @@ jobs:
           commit: true
           url: ${{ secrets.SLACK_BUILD_WEBHOOK }}
           token: ${{ secrets.SLACK_GITHUB_TOKEN }}
+
+  # https://github.com/marketplace/actions/alls-green#why
+  check:  # This job does nothing and is only used for the branch protection
+    if: always()
+
+    needs:
+      - build
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Decide whether the needed jobs succeeded or failed
+        uses: re-actors/alls-green@release/v1
+        with:
+          jobs: ${{ toJSON(needs) }}


### PR DESCRIPTION
This patch is intended to lower the maintenance burden of having to manually go through each matrix subjob name in the branch protection repository settings. It allows to only include the check job in the branch protection and it will robustly determine if the dependencies have succeeded or not.

It is currently mostly serves the Python ecosystem in projects like aiohttp, cryptography, open edX, pip etc. But I've also seen other communities picking it up lately, like the AWS Rust SDK and even the engine powering https://dev.to, to my surprise. Strictly speaking, it is agnostic.

Ref: https://github.com/marketplace/actions/alls-green#why