### PR TITLE
Allow change of project_name variable

### DIFF
--- a/platformio/project/integration/generator.py
+++ b/platformio/project/integration/generator.py
@@ -94,6 +94,10 @@ class ProjectGenerator:
             "env_pathsep": os.pathsep,
         }
 
+        # rewrite project_name from configuration
+        platformio_config_vars = self.config.items(section="platformio", as_dict=True)
+        if "project_name" in platformio_config_vars:
+            tpl_vars["project_name"] = platformio_config_vars["project_name"]
         # default env configuration
         tpl_vars.update(self.config.items(env=self.env_name, as_dict=True))
         # build data

--- a/platformio/project/options.py
+++ b/platformio/project/options.py
@@ -157,6 +157,11 @@ ProjectOptions = OrderedDict(
                 ),
                 multiple=True,
             ),
+            ConfigPlatformioOption(
+                group="generic",
+                name="project_name",
+                description="Configure project name manually",
+            ),
             # Dirs
             ConfigPlatformioOption(
                 group="directory",


### PR DESCRIPTION
This commit intends to introduce new feature of manally configurable project name which is exported to various IDE configurations. New configuration option in platformio.ini in section [platformio] is introduced: project_name. When this option is set, the current (default) value of project_name which is get from project directory basename is replaced by the configured value.