### PR TITLE
changed bmp gdb init

### DIFF
--- a/platformio/debug/config/blackmagic.MD
+++ b/platformio/debug/config/blackmagic.MD
@@ -1,0 +1,28 @@
+# Blackmagic Probe improvements
+
+I needed SRST under reset feature, this command has to be issued before scan, but this is currently impossible with current variables.
+
+By changing the gdb init a bit this or even target power is possible
+
+See: "Embedded Debugging with the Black Magic Probe", pp. 28
+
+```
+upload_protocol = blackmagic
+upload_port = /dev/ttyBmpGdb
+debug_tool = blackmagic
+debug_port = ${this.upload_port} connect_srst
+monitor_port = /dev/ttyBmpTarg
+monitor_speed = 115200
+
+```
+
+debug_port = port [monitor_cmd]
+
+debug_port can be /dev/ttyACM0 (/dev/ttyBmpGdb if you use the udev rules) or a Windows COM port, I use `${this.upload_port}` to use the same.
+
+An optional param can be used to enable eg:
+
+- tpwr (Target Power)
+- connect_srst (Assert SRST during connect)
+
+Currently it's not possibe to enable both, but this can easily be changed (iterate over args)

--- a/platformio/debug/config/blackmagic.py
+++ b/platformio/debug/config/blackmagic.py
@@ -20,12 +20,25 @@ from platformio.device.finder import SerialPortFinder, is_pattern_port
 class BlackmagicDebugConfig(DebugConfigBase):
 
     GDB_INIT_SCRIPT = """
+define bmconnect
+  target extended-remote $arg0
+  set $i = 1
+  while $i < $argc
+    eval "monitor $arg%d enable", $i
+    set $i = $i + 1
+  end
+  monitor swdp_scan
+  attach 1
+end
+
 define pio_reset_halt_target
     set language c
     set *0xE000ED0C = 0x05FA0004
-    set $busy = (*0xE000ED0C & 0x4)
-    while ($busy)
+    while (1)
         set $busy = (*0xE000ED0C & 0x4)
+        if (! $busy)
+            loop_break
+        end
     end
     set language auto
 end
@@ -34,20 +47,12 @@ define pio_reset_run_target
     pio_reset_halt_target
 end
 
-target extended-remote $DEBUG_PORT
-monitor swdp_scan
-attach 1
+bmconnect $DEBUG_PORT
 set mem inaccessible-by-default off
 $LOAD_CMDS
 $INIT_BREAK
 
-set language c
-set *0xE000ED0C = 0x05FA0004
-set $busy = (*0xE000ED0C & 0x4)
-while ($busy)
-    set $busy = (*0xE000ED0C & 0x4)
-end
-set language auto
+pio_reset_halt_target
 """
 
     @property


### PR DESCRIPTION
# Blackmagic Probe improvements

I needed SRST under reset feature, this command has to be issued before scan, but this is currently impossible with current variables.

By changing the gdb init a bit this or even target power is possible

See: "Embedded Debugging with the Black Magic Probe", pp. 28

```
upload_protocol = blackmagic
upload_port = /dev/ttyBmpGdb
debug_tool = blackmagic
debug_port = ${this.upload_port} connect_srst
monitor_port = /dev/ttyBmpTarg
monitor_speed = 115200

```

debug_port = port [monitor_cmd]

debug_port can be /dev/ttyACM0 (/dev/ttyBmpGdb if you use the udev rules) or a Windows COM port, I use `${this.upload_port}` to use the same.

An optional param can be used to enable eg:

- tpwr (Target Power)
- connect_srst (Assert SRST during connect)

Currently it's not possibe to enable both, but this can easily be changed (iterate over args)
