### PR TITLE
Improved file filtering for the Static Analysis feature

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -20,6 +20,7 @@ PlatformIO Core 6
 * Show detailed library dependency tree only in the `verbose mode <https://docs.platformio.org/en/latest/core/userguide/cmd_run.html#cmdoption-pio-run-v>`__ (`issue #4517 <https://github.com/platformio/platformio-core/issues/4517>`_)
 * Prevented shell injection when converting INO file to CPP (`issue #4532 <https://github.com/platformio/platformio-core/issues/4532>`_)
 * Restored project generator for `NetBeans IDE <https://docs.platformio.org/en/latest/integration/ide/netbeans.html>`__
+* Improved source file filtering functionality for `Static Code Analysis <https://docs.platformio.org/en/latest/advanced/static-code-analysis/index.html>`__ feature
 
 6.1.6 (2023-01-23)
 ~~~~~~~~~~~~~~~~~~

--- a/platformio/check/cli.py
+++ b/platformio/check/cli.py
@@ -116,7 +116,7 @@ def cli(
                 src_filter
                 or pattern
                 or env_options.get(
-                    "check_src_filter",
+                    "check_src_filters",
                     env_options.get("check_patterns", default_src_filter),
                 )
             )

--- a/platformio/check/cli.py
+++ b/platformio/check/cli.py
@@ -50,7 +50,11 @@ from platformio.project.helpers import find_project_dir_above, get_project_dir
     ),
 )
 @click.option("--pattern", multiple=True, hidden=True)
-@click.option("--src-filter", multiple=True)
+@click.option(
+    "-f",
+    "--src-filters",
+    multiple=True
+)
 @click.option("--flags", multiple=True)
 @click.option(
     "--severity", multiple=True, type=click.Choice(DefectItem.SEVERITY_LABELS.values())
@@ -68,7 +72,7 @@ def cli(
     environment,
     project_dir,
     project_conf,
-    src_filter,
+    src_filters,
     pattern,
     flags,
     severity,
@@ -107,24 +111,24 @@ def cli(
                     "%s: %s" % (k, ", ".join(v) if isinstance(v, list) else v)
                 )
 
-            default_src_filter = [
+            default_src_filters = [
                 "+<%s>" % os.path.basename(config.get("platformio", "src_dir")),
                 "+<%s>" % os.path.basename(config.get("platformio", "include_dir")),
             ]
 
-            src_filter = (
-                src_filter
+            src_filters = (
+                src_filters
                 or pattern
                 or env_options.get(
                     "check_src_filters",
-                    env_options.get("check_patterns", default_src_filter),
+                    env_options.get("check_patterns", default_src_filters),
                 )
             )
 
             tool_options = dict(
                 verbose=verbose,
                 silent=silent,
-                src_filter=src_filter,
+                src_filters=src_filters,
                 flags=flags or env_options.get("check_flags"),
                 severity=[DefectItem.SEVERITY_LABELS[DefectItem.SEVERITY_HIGH]]
                 if silent

--- a/platformio/check/cli.py
+++ b/platformio/check/cli.py
@@ -115,7 +115,10 @@ def cli(
             src_filter = (
                 src_filter
                 or pattern
-                or env_options.get("check_src_filter", default_src_filter)
+                or env_options.get(
+                    "check_src_filter",
+                    env_options.get("check_patterns", default_src_filter),
+                )
             )
 
             tool_options = dict(

--- a/platformio/check/tools/base.py
+++ b/platformio/check/tools/base.py
@@ -208,7 +208,7 @@ class CheckToolBase:  # pylint: disable=too-many-instance-attributes
         return result
 
     @staticmethod
-    def get_project_target_files(project_dir, src_filter):
+    def get_project_target_files(project_dir, src_filters):
         c_extension = (".c",)
         cpp_extensions = (".cc", ".cpp", ".cxx", ".ino")
         header_extensions = (".h", ".hh", ".hpp", ".hxx")
@@ -223,8 +223,8 @@ class CheckToolBase:  # pylint: disable=too-many-instance-attributes
             elif path.endswith(cpp_extensions):
                 result["c++"].append(os.path.abspath(path))
 
-        src_filter = normalize_src_filter(src_filter)
-        for f in fs.match_src_files(project_dir, src_filter):
+        src_filters = normalize_src_filters(src_filters)
+        for f in fs.match_src_files(project_dir, src_filters):
             _add_file(f)
 
         return result
@@ -253,13 +253,13 @@ class CheckToolBase:  # pylint: disable=too-many-instance-attributes
 #
 
 
-def normalize_src_filter(src_filter):
-    def _normalize(src_filter):
+def normalize_src_filters(src_filters):
+    def _normalize(src_filters):
         return (
-            src_filter if src_filter.startswith(("+<", "-<")) else "+<%s>" % src_filter
+            src_filters if src_filters.startswith(("+<", "-<")) else "+<%s>" % src_filters
         )
 
-    if isinstance(src_filter, (list, tuple)):
-        return " ".join([_normalize(f) for f in src_filter])
+    if isinstance(src_filters, (list, tuple)):
+        return " ".join([_normalize(f) for f in src_filters])
 
-    return _normalize(src_filter)
+    return _normalize(src_filters)

--- a/platformio/check/tools/clangtidy.py
+++ b/platformio/check/tools/clangtidy.py
@@ -64,7 +64,9 @@ class ClangtidyCheckTool(CheckToolBase):
         ):
             cmd.append("--checks=*")
 
-        project_files = self.get_project_target_files(self.options["patterns"])
+        project_files = self.get_project_target_files(
+            self.project_dir, self.options["src_filter"]
+        )
 
         src_files = []
         for items in project_files.values():

--- a/platformio/check/tools/clangtidy.py
+++ b/platformio/check/tools/clangtidy.py
@@ -65,7 +65,7 @@ class ClangtidyCheckTool(CheckToolBase):
             cmd.append("--checks=*")
 
         project_files = self.get_project_target_files(
-            self.project_dir, self.options["src_filter"]
+            self.project_dir, self.options["src_filters"]
         )
 
         src_files = []

--- a/platformio/check/tools/cppcheck.py
+++ b/platformio/check/tools/cppcheck.py
@@ -215,7 +215,7 @@ class CppcheckCheckTool(CheckToolBase):
             return
 
         for files in self.get_project_target_files(
-            self.project_dir, self.options["src_filter"]
+            self.project_dir, self.options["src_filters"]
         ).values():
             for f in files:
                 dump_file = f + ".dump"
@@ -246,7 +246,7 @@ class CppcheckCheckTool(CheckToolBase):
         self._on_defect_callback = on_defect_callback
 
         project_files = self.get_project_target_files(
-            self.project_dir, self.options["src_filter"]
+            self.project_dir, self.options["src_filters"]
         )
         src_files_scope = ("c", "c++")
         if not any(project_files[t] for t in src_files_scope):

--- a/platformio/check/tools/cppcheck.py
+++ b/platformio/check/tools/cppcheck.py
@@ -96,7 +96,7 @@ class CppcheckCheckTool(CheckToolBase):
                     )
                     click.echo()
                 self._bad_input = True
-                self._buffer = ""
+            self._buffer = ""
             return None
 
         self._buffer = ""
@@ -214,7 +214,9 @@ class CppcheckCheckTool(CheckToolBase):
         if not self.is_flag_set("--addon", self.get_flags("cppcheck")):
             return
 
-        for files in self.get_project_target_files(self.options["patterns"]).values():
+        for files in self.get_project_target_files(
+            self.project_dir, self.options["src_filter"]
+        ).values():
             for f in files:
                 dump_file = f + ".dump"
                 if os.path.isfile(dump_file):
@@ -243,7 +245,9 @@ class CppcheckCheckTool(CheckToolBase):
     def check(self, on_defect_callback=None):
         self._on_defect_callback = on_defect_callback
 
-        project_files = self.get_project_target_files(self.options["patterns"])
+        project_files = self.get_project_target_files(
+            self.project_dir, self.options["src_filter"]
+        )
         src_files_scope = ("c", "c++")
         if not any(project_files[t] for t in src_files_scope):
             click.echo("Error: Nothing to check.")

--- a/platformio/check/tools/pvsstudio.py
+++ b/platformio/check/tools/pvsstudio.py
@@ -227,7 +227,7 @@ class PvsStudioCheckTool(CheckToolBase):  # pylint: disable=too-many-instance-at
     def check(self, on_defect_callback=None):
         self._on_defect_callback = on_defect_callback
         for scope, files in self.get_project_target_files(
-            self.options["patterns"]
+            self.project_dir, self.options["src_filter"]
         ).items():
             if scope not in ("c", "c++"):
                 continue

--- a/platformio/check/tools/pvsstudio.py
+++ b/platformio/check/tools/pvsstudio.py
@@ -227,7 +227,7 @@ class PvsStudioCheckTool(CheckToolBase):  # pylint: disable=too-many-instance-at
     def check(self, on_defect_callback=None):
         self._on_defect_callback = on_defect_callback
         for scope, files in self.get_project_target_files(
-            self.project_dir, self.options["src_filter"]
+            self.project_dir, self.options["src_filters"]
         ).items():
             if scope not in ("c", "c++"):
                 continue

--- a/platformio/project/options.py
+++ b/platformio/project/options.py
@@ -649,7 +649,7 @@ ProjectOptions = OrderedDict(
             ),
             ConfigEnvOption(
                 group="check",
-                name="check_src_filter",
+                name="check_src_filters",
                 oldnames=["check_patterns"],
                 description=(
                     "Configure a list of target files or directories for checking "

--- a/platformio/project/options.py
+++ b/platformio/project/options.py
@@ -649,7 +649,8 @@ ProjectOptions = OrderedDict(
             ),
             ConfigEnvOption(
                 group="check",
-                name="check_patterns",
+                name="check_src_filter",
+                oldnames=["check_patterns"],
                 description=(
                     "Configure a list of target files or directories for checking "
                     "(Unix shell-style wildcards)"

--- a/tests/commands/test_check.py
+++ b/tests/commands/test_check.py
@@ -668,7 +668,7 @@ def test_check_src_filter_from_config(clirunner, validate_cliresult, tmpdir_fact
     config = (
         DEFAULT_CONFIG
         + """
-check_src_filter =
+check_src_filters =
     +<src/spi/*.c*>
     +<tests/test.cpp>
     """
@@ -686,6 +686,7 @@ check_src_filter =
     errors, warnings, style = count_defects(result.output)
 
     assert errors + warnings + style == EXPECTED_DEFECTS * 2
+    assert "main.cpp" not in result.output
 
 
 def test_check_custom_pattern_absolute_path_legacy(

--- a/tests/commands/test_check.py
+++ b/tests/commands/test_check.py
@@ -758,3 +758,4 @@ check_patterns =
     errors, warnings, style = count_defects(result.output)
 
     assert errors + warnings + style == EXPECTED_DEFECTS * 2
+    assert "main.cpp" not in result.output

--- a/tests/commands/test_check.py
+++ b/tests/commands/test_check.py
@@ -651,7 +651,7 @@ def test_check_src_filter(
     tmpdir.mkdir("tests").join("test.cpp").write(TEST_CODE)
 
     cmd_args = ["--project-dir", str(tmpdir)] + [
-        "--src-filter=%s" % f for f in src_filter
+        "--src-filters=%s" % f for f in src_filter
     ]
 
     result = clirunner.invoke(cmd_check, cmd_args)

--- a/tests/commands/test_check.py
+++ b/tests/commands/test_check.py
@@ -15,8 +15,8 @@
 # pylint: disable=redefined-outer-name
 
 import json
+import os
 import sys
-from os.path import isfile, join
 
 import pytest
 
@@ -83,12 +83,12 @@ def check_dir(tmpdir_factory):
 
 def count_defects(output):
     error, warning, style = 0, 0, 0
-    for l in output.split("\n"):
-        if "[high:error]" in l:
+    for line in output.split("\n"):
+        if "[high:error]" in line:
             error += 1
-        elif "[medium:warning]" in l:
+        elif "[medium:warning]" in line:
             warning += 1
-        elif "[low:style]" in l:
+        elif "[low:style]" in line:
             style += 1
     return error, warning, style
 
@@ -240,9 +240,9 @@ def test_check_includes_passed(clirunner, check_dir):
     result = clirunner.invoke(cmd_check, ["--project-dir", str(check_dir), "--verbose"])
 
     inc_count = 0
-    for l in result.output.split("\n"):
-        if l.startswith("Includes:"):
-            inc_count = l.count("-I")
+    for line in result.output.split("\n"):
+        if line.startswith("Includes:"):
+            inc_count = line.count("-I")
 
     # at least 1 include path for default mode
     assert inc_count > 0
@@ -257,46 +257,6 @@ def test_check_silent_mode(clirunner, validate_cliresult, check_dir):
     assert errors == EXPECTED_ERRORS
     assert warnings == 0
     assert style == 0
-
-
-def test_check_custom_pattern_absolute_path(
-    clirunner, validate_cliresult, tmpdir_factory
-):
-    project_dir = tmpdir_factory.mktemp("project")
-    project_dir.join("platformio.ini").write(DEFAULT_CONFIG)
-
-    check_dir = tmpdir_factory.mktemp("custom_src_dir")
-    check_dir.join("main.cpp").write(TEST_CODE)
-
-    result = clirunner.invoke(
-        cmd_check, ["--project-dir", str(project_dir), "--pattern=" + str(check_dir)]
-    )
-    validate_cliresult(result)
-
-    errors, warnings, style = count_defects(result.output)
-
-    assert errors == EXPECTED_ERRORS
-    assert warnings == EXPECTED_WARNINGS
-    assert style == EXPECTED_STYLE
-
-
-def test_check_custom_pattern_relative_path(
-    clirunner, validate_cliresult, tmpdir_factory
-):
-    tmpdir = tmpdir_factory.mktemp("project")
-    tmpdir.join("platformio.ini").write(DEFAULT_CONFIG)
-
-    tmpdir.mkdir("app").join("main.cpp").write(TEST_CODE)
-    tmpdir.mkdir("prj").join("test.cpp").write(TEST_CODE)
-
-    result = clirunner.invoke(
-        cmd_check, ["--project-dir", str(tmpdir), "--pattern=app", "--pattern=prj"]
-    )
-    validate_cliresult(result)
-
-    errors, warnings, style = count_defects(result.output)
-
-    assert errors + warnings + style == EXPECTED_DEFECTS * 2
 
 
 def test_check_no_source_files(clirunner, tmpdir):
@@ -427,7 +387,7 @@ R21.4 text.
 
     validate_cliresult(result)
     assert "R21.3 Found MISRA defect" in result.output
-    assert not isfile(join(str(check_dir), "src", "main.cpp.dump"))
+    assert not os.path.isfile(os.path.join(str(check_dir), "src", "main.cpp.dump"))
 
 
 def test_check_fails_on_defects_only_with_flag(clirunner, validate_cliresult, tmpdir):
@@ -607,10 +567,10 @@ framework = arduino
     validate_cliresult(result)
 
     project_path = fs.to_unix_path(str(tmpdir))
-    for l in result.output.split("\n"):
-        if not l.startswith("Includes:"):
+    for line in result.output.split("\n"):
+        if not line.startswith("Includes:"):
             continue
-        for inc in l.split(" "):
+        for inc in line.split(" "):
             if inc.startswith("-I") and project_path not in inc:
                 pytest.fail("Detected an include path from packages: " + inc)
 
@@ -656,3 +616,145 @@ def test_check_handles_spaces_in_paths(clirunner, validate_cliresult, tmpdir_fac
     default_result = clirunner.invoke(cmd_check, ["--project-dir", str(tmpdir)])
 
     validate_cliresult(default_result)
+
+
+#
+# Files filtering functionality
+#
+
+
+@pytest.mark.parametrize(
+    "src_filter,number_of_checked_files",
+    [
+        (["+<src/app.cpp>"], 1),
+        (["+<tests/*.cpp>"], 1),
+        (["+<src>", "-<src/*.cpp>"], 2),
+        (["-<*> +<src/main.cpp> +<src/uart/uart.cpp> +<src/spi/spi.cpp>"], 3),
+    ],
+    ids=["Single file", "Glob pattern", "Exclude pattern", "Filter as string"],
+)
+def test_check_src_filter(
+    clirunner,
+    validate_cliresult,
+    tmpdir_factory,
+    src_filter,
+    number_of_checked_files,
+):
+    tmpdir = tmpdir_factory.mktemp("project")
+    tmpdir.join("platformio.ini").write(DEFAULT_CONFIG)
+
+    src_dir = tmpdir.mkdir("src")
+    src_dir.join("main.cpp").write(TEST_CODE)
+    src_dir.join("app.cpp").write(TEST_CODE)
+    src_dir.mkdir("uart").join("uart.cpp").write(TEST_CODE)
+    src_dir.mkdir("spi").join("spi.cpp").write(TEST_CODE)
+    tmpdir.mkdir("tests").join("test.cpp").write(TEST_CODE)
+
+    cmd_args = ["--project-dir", str(tmpdir)] + [
+        "--src-filter=%s" % f for f in src_filter
+    ]
+
+    result = clirunner.invoke(cmd_check, cmd_args)
+    validate_cliresult(result)
+
+    errors, warnings, style = count_defects(result.output)
+
+    assert errors + warnings + style == EXPECTED_DEFECTS * number_of_checked_files
+
+
+def test_check_src_filter_from_config(clirunner, validate_cliresult, tmpdir_factory):
+    tmpdir = tmpdir_factory.mktemp("project")
+
+    config = (
+        DEFAULT_CONFIG
+        + """
+check_src_filter =
+    +<src/spi/*.c*>
+    +<tests/test.cpp>
+    """
+    )
+    tmpdir.join("platformio.ini").write(config)
+
+    src_dir = tmpdir.mkdir("src")
+    src_dir.join("main.cpp").write(TEST_CODE)
+    src_dir.mkdir("spi").join("spi.cpp").write(TEST_CODE)
+    tmpdir.mkdir("tests").join("test.cpp").write(TEST_CODE)
+
+    result = clirunner.invoke(cmd_check, ["--project-dir", str(tmpdir)])
+    validate_cliresult(result)
+
+    errors, warnings, style = count_defects(result.output)
+
+    assert errors + warnings + style == EXPECTED_DEFECTS * 2
+
+
+def test_check_custom_pattern_absolute_path_legacy(
+    clirunner, validate_cliresult, tmpdir_factory
+):
+    project_dir = tmpdir_factory.mktemp("project")
+    project_dir.join("platformio.ini").write(DEFAULT_CONFIG)
+
+    check_dir = tmpdir_factory.mktemp("custom_src_dir")
+    check_dir.join("main.cpp").write(TEST_CODE)
+
+    result = clirunner.invoke(
+        cmd_check, ["--project-dir", str(project_dir), "--pattern=" + str(check_dir)]
+    )
+
+    validate_cliresult(result)
+
+    errors, warnings, style = count_defects(result.output)
+
+    assert errors == EXPECTED_ERRORS
+    assert warnings == EXPECTED_WARNINGS
+    assert style == EXPECTED_STYLE
+
+
+def test_check_custom_pattern_relative_path_legacy(
+    clirunner, validate_cliresult, tmpdir_factory
+):
+    tmpdir = tmpdir_factory.mktemp("project")
+    tmpdir.join("platformio.ini").write(DEFAULT_CONFIG)
+
+    src_dir = tmpdir.mkdir("src")
+    src_dir.join("main.cpp").write(TEST_CODE)
+    src_dir.mkdir("uart").join("uart.cpp").write(TEST_CODE)
+    src_dir.mkdir("spi").join("spi.cpp").write(TEST_CODE)
+
+    result = clirunner.invoke(
+        cmd_check,
+        ["--project-dir", str(tmpdir), "--pattern=src/uart", "--pattern=src/spi"],
+    )
+    validate_cliresult(result)
+
+    errors, warnings, style = count_defects(result.output)
+
+    assert errors + warnings + style == EXPECTED_DEFECTS * 2
+
+
+def test_check_src_filter_from_config_legacy(
+    clirunner, validate_cliresult, tmpdir_factory
+):
+    tmpdir = tmpdir_factory.mktemp("project")
+
+    config = (
+        DEFAULT_CONFIG
+        + """
+check_patterns =
+    src/spi/*.c*
+    tests/test.cpp
+    """
+    )
+    tmpdir.join("platformio.ini").write(config)
+
+    src_dir = tmpdir.mkdir("src")
+    src_dir.join("main.cpp").write(TEST_CODE)
+    src_dir.mkdir("spi").join("spi.cpp").write(TEST_CODE)
+    tmpdir.mkdir("tests").join("test.cpp").write(TEST_CODE)
+
+    result = clirunner.invoke(cmd_check, ["--project-dir", str(tmpdir)])
+    validate_cliresult(result)
+
+    errors, warnings, style = count_defects(result.output)
+
+    assert errors + warnings + style == EXPECTED_DEFECTS * 2


### PR DESCRIPTION
This PR introduces refactored functionality for source files filtering via templates, for example:
```ini
[env:check_src_filter]
platform = ...
board = ...
check_src_filters =
  -<src/*>
  +<src/spi/spi.cpp>
  -<tests/>
  +<tests/test_embedded/*.c*>
```



Resolves #4566 