### PR TITLE
InoToCpp: add ':' to arguments regexp

### DIFF
--- a/platformio/builder/tools/pioino.py
+++ b/platformio/builder/tools/pioino.py
@@ -30,7 +30,7 @@ class InoToCPPConverter:
         (?:template\<.*\>\s*)?      # template
         ([a-z_\d\&]+\*?\s+){1,2}    # return type
         ([a-z_\d]+\s*)              # name of prototype
-        \([a-z_,\.\*\&\[\]\s\d]*\)  # arguments
+        \([a-z_:,\.\*\&\[\]\s\d]*\) # arguments
         )\s*(\{|;)                  # must end with `{` or `;`
         """,
         re.X | re.M | re.I,


### PR DESCRIPTION
Noticed while building .ino files at esp8266 repo
https://github.com/esp8266/Arduino/actions/runs/4578253831/jobs/8084637114?pr=8901#step:5:174

```
  /tmp/tmpo60cxu_1/src/onewiretest.ino: In function 'void loop()':
  /tmp/tmpo60cxu_1/src/onewiretest.ino:31:2: error: 'checkSwSerial' was not declared in this scope
     31 |  checkSwSerial(&swSer1);
        |  ^~~~~~~~~~~~~
  *** [.pio/build/nodemcuv2/src/onewiretest.ino.cpp.o] Error 1
```

Where the signature should be
```
void checkSwSerial(EspSoftwareSerial::UART*);
```

Locally, to reproduce
```
> git clone https://github.com/plerup/espsoftwareserial/
> pushd espsoftwareserial/examples/onewiretest
> pio ci -b esp32dev -l "$PWD/../../" ./