### PR TITLE
test/runners/unity.py: fixed warnings: `[-Wunused-parameter]`

### DIFF
--- a/platformio/test/runners/unity.py
+++ b/platformio/test/runners/unity.py
@@ -114,7 +114,7 @@ $framework_config_code
         native=dict(
             code="""
 #include <stdio.h>
-void unityOutputStart(unsigned long baudrate) { }
+void unityOutputStart(unsigned long baudrate) { (void) baudrate; }
 void unityOutputChar(unsigned int c) { putchar(c); }
 void unityOutputFlush(void) { fflush(stdout); }
 void unityOutputComplete(void) { }
@@ -155,7 +155,7 @@ void unityOutputComplete(void) { }
         espidf=dict(
             code="""
 #include <stdio.h>
-void unityOutputStart(unsigned long baudrate) { }
+void unityOutputStart(unsigned long baudrate) { (void) baudrate; }
 void unityOutputChar(unsigned int c) { putchar(c); }
 void unityOutputFlush(void) { fflush(stdout); }
 void unityOutputComplete(void) { }
@@ -165,7 +165,7 @@ void unityOutputComplete(void) { }
         zephyr=dict(
             code="""
 #include <sys/printk.h>
-void unityOutputStart(unsigned long baudrate) { }
+void unityOutputStart(unsigned long baudrate) { (void) baudrate; }
 void unityOutputChar(unsigned int c) { printk("%c", c); }
 void unityOutputFlush(void) { }
 void unityOutputComplete(void) { }


### PR DESCRIPTION
They appear when the tests are run with the `Wextra` flag.

I know of 3 possible solutions:
* A.) `static_cast<void>(unusedParameter);` – the preferred C++ way, but `unity` can also be used with `C`
* B.) `(void) unusedParameter;` – "old" C–style casting – the one I used – compatible with both C and C++
* C.) remove `unusedParameter` var from the function arguments – but keeping the name better explains what it is

```
Library Manager: Installing throwtheswitch/Unity @ ^2.5.2
Unpacking  [####################################]  100%
Library Manager: Unity@2.5.2 has been installed!
.pio/build/native/unity_config/unity_config.c:39:37: warning: unused parameter 'baudrate' [-Wunused-parameter]
void unityOutputStart(unsigned long baudrate) { }
                                    ^
1 warning generated.
Testing...
```