### PR TITLE
`__eq__`s check for the class of `other`s

### DIFF
--- a/platformio/package/commands/outdated.py
+++ b/platformio/package/commands/outdated.py
@@ -36,7 +36,7 @@ class OutdatedCandidate:
             self.envs = [self.envs]
 
     def __eq__(self, other):
-        return all(
+        return isinstance(other, OutdatedCandidate) and all(
             [
                 self.pm.package_dir == other.pm.package_dir,
                 self.pkg == other.pkg,

--- a/platformio/package/meta.py
+++ b/platformio/package/meta.py
@@ -183,7 +183,7 @@ class PackageSpec:  # pylint: disable=too-many-instance-attributes
         self._parse(self.raw)
 
     def __eq__(self, other):
-        return all(
+        return isinstance(other, PackageSpec) and all(
             [
                 self.owner == other.owner,
                 self.id == other.id,
@@ -418,7 +418,7 @@ class PackageMetaData:
         )
 
     def __eq__(self, other):
-        return all(
+        return isinstance(other, PackageMetaData) and all(
             [
                 self.type == other.type,
                 self.name == other.name,
@@ -481,13 +481,14 @@ class PackageItem:
         )
 
     def __eq__(self, other):
-        conds = [
-            os.path.realpath(self.path) == os.path.realpath(other.path)
-            if self.path and other.path
-            else self.path == other.path,
-            self.metadata == other.metadata,
-        ]
-        return all(conds)
+        return isinstance(other, PackageItem) and all(
+            [
+                os.path.realpath(self.path) == os.path.realpath(other.path)
+                if self.path and other.path
+                else self.path == other.path,
+                self.metadata == other.metadata,
+            ]
+        )
 
     def __hash__(self):
         return hash(os.path.realpath(self.path))


### PR DESCRIPTION
Fixes errors like…

```
AttributeError: 'Version' object has no attribute 'owner':
  File "/usr/local/Cellar/platformio/6.1.6/libexec/lib/python3.11/site-packages/platformio/package/meta.py", line 188
```

…when trying to compare the objects to other objects that are not of the same class.

---

I came up with the issue when trying to debug my [PIO's extra script](https://docs.platformio.org/en/latest/projectconf/sections/env/options/advanced/extra_scripts.html) with `var_dump`:

```python
Import("env")
env.Execute("$PYTHONEXE -m pip install 'var_dump @ git+https://github.com/sha256/python-var-dump@972d05bff13fd57366f56bd36b70e1ab15d6173d' --force-reinstall")
from var_dump import var_dump
var_dump(env.PioPlatform())
```