### PR TITLE
Fix CMakeLists.txt.tpl to use local compiler

### DIFF
--- a/platformio/project/integration/tpls/clion/CMakeLists.txt.tpl
+++ b/platformio/project/integration/tpls/clion/CMakeLists.txt.tpl
@@ -10,9 +10,9 @@ set(CMAKE_SYSTEM_NAME Generic)
 set(CMAKE_C_COMPILER_WORKS 1)
 set(CMAKE_CXX_COMPILER_WORKS 1)
 
-project("{{project_name}}" C CXX)
-
 include(CMakeListsPrivate.txt)
+
+project("{{project_name}}" C CXX)
 
 if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/CMakeListsUser.txt)
 include(CMakeListsUser.txt)


### PR DESCRIPTION
The CMakeListsPrivate.txt is included after defining the project (with the "project" command). It should be the other way around since the C and C++ compilers are defined in CMakeListsPrivate.txt. The compiler definition always goes before the project definition, otherwise it is ignored by CMake. Since it is not the case here, CLion will tell CMake to try detecting the system compiler, which is probably not the one being used by the project. This may works if it the system compiler is a GNU compiler, but will not work otherwise (eg. with MSVC installed and set as the default in CLion). The solution is simply to include CMakeListsPrivate.txt before defining the project.