### PR TITLE
unity.py: fixing whitespace issue when running tests with `-Wpedantic`

### DIFF
--- a/platformio/test/runners/unity.py
+++ b/platformio/test/runners/unity.py
@@ -118,7 +118,7 @@ void unityOutputStart(unsigned long baudrate) { (void) baudrate; }
 void unityOutputChar(unsigned int c) { putchar(c); }
 void unityOutputFlush(void) { fflush(stdout); }
 void unityOutputComplete(void) { }
-        """,
+        """.strip(' '),
             language="c",
         ),
         arduino=dict(
@@ -159,7 +159,7 @@ void unityOutputStart(unsigned long baudrate) { (void) baudrate; }
 void unityOutputChar(unsigned int c) { putchar(c); }
 void unityOutputFlush(void) { fflush(stdout); }
 void unityOutputComplete(void) { }
-        """,
+        """.strip(' '),
             language="c",
         ),
         zephyr=dict(


### PR DESCRIPTION
```
pio test

[…]

Library Manager: Installing throwtheswitch/Unity @ ^2.5.2
Unpacking  [####################################]  100%
Library Manager: Unity@2.5.2 has been installed!
.pio/build/native/unity_config/unity_config.c:44:5: warning: no newline at end of file [-Wnewline-eof]

    ^
1 warning generated.
Testing...
```

There used to be a blank line with 4 spaces in the generated code -> `strip(' ')` removes the spaces, leaving the blank line intact.