### PR TITLE
config.py: removed unused var

### DIFF
--- a/platformio/project/config.py
+++ b/platformio/project/config.py
@@ -339,7 +339,6 @@ class ProjectConfigBase:
         return str(value)
 
     def get(self, section, option, default=MISSING):
-        value = None
         try:
             value = self.getraw(section, option, default)
         except configparser.Error as exc:


### PR DESCRIPTION
it is immediately overwritten within the try–except block