### PR TITLE
Comply with XDG specification

### DIFF
--- a/platformio/project/options.py
+++ b/platformio/project/options.py
@@ -118,7 +118,11 @@ def validate_dir(path):
 
 
 def get_default_core_dir():
-    path = os.path.join(fs.expanduser("~"), ".platformio")
+    xdg_config_home = os.environ.get("XDG_CONFIG_HOME")
+    if xdg_config_home:
+        path = os.path.join(xdg_config_home, "platformio")
+    else:
+        path = os.path.join(fs.expanduser("~"), ".config", "platformio")
     if IS_WINDOWS:
         win_core_dir = os.path.splitdrive(path)[0] + "\\.platformio"
         if os.path.isdir(win_core_dir):


### PR DESCRIPTION
Modified `get_default_core_dir()` so that it respects the XDG specification and does not clutter people's home directories with `.platformio` folders. See issue #2872.

I left Windows alone since they don't really do XDG - I believe they have their own conventions, e.g. `%APPDATA%` and stuff like that. Platformio also doesn't adhere these, but I'll leave that to someone else to figure out.

Besides that, I also had to modify `test_config.py` so that it would not freak out because of the changes in `options.py`.

More info about the XDG specification:
https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html
https://xdgbasedirectoryspecification.com/