### PR TITLE
Issue #4762 compiledb include toolchains with user defined libs

### DIFF
--- a/platformio/builder/tools/piobuild.py
+++ b/platformio/builder/tools/piobuild.py
@@ -126,6 +126,12 @@ def ProcessProgramDeps(env):
     # remove specified flags
     env.ProcessUnFlags(env.get("BUILD_UNFLAGS"))
 
+    env.ProcessCompileDbToolchainOption()
+
+
+def ProcessCompileDbToolchainOption(
+    env,
+):  # separated out to selectively add to lib build step
     if "compiledb" in COMMAND_LINE_TARGETS:
         # Resolve absolute path of toolchain
         for cmd in ("CC", "CXX", "AS"):
@@ -138,6 +144,7 @@ def ProcessProgramDeps(env):
             )
 
         if env.get("COMPILATIONDB_INCLUDE_TOOLCHAIN"):
+            print("Warning! `COMPILATIONDB_INCLUDE_TOOLCHAIN` is scoping")
             for scope, includes in env.DumpIntegrationIncludes().items():
                 if scope in ("toolchain",):
                     env.Append(CPPPATH=includes)
@@ -376,6 +383,7 @@ def generate(env):
     env.AddMethod(GetBuildType)
     env.AddMethod(BuildProgram)
     env.AddMethod(ProcessProgramDeps)
+    env.AddMethod(ProcessCompileDbToolchainOption)
     env.AddMethod(ProcessProjectDeps)
     env.AddMethod(ParseFlagsExtended)
     env.AddMethod(ProcessFlags)

--- a/platformio/builder/tools/piolib.py
+++ b/platformio/builder/tools/piolib.py
@@ -478,6 +478,8 @@ class LibBuilderBase:
 
         self.env.PrependUnique(CPPPATH=self.get_include_dirs())
 
+        self.env.ProcessCompileDbToolchainOption()
+
         if self.lib_ldf_mode == "off":
             for lb in self.env.GetLibBuilders():
                 if self == lb or not lb.is_built:


### PR DESCRIPTION
separated out the optional addition of toolchains to compiledb include paths and added a call to it in the library building step for user defined libraries, allowing the automatic inclusion of toolchains in private lib compiledb generation

related to issue #4762 