### PR TITLE
Add STM32 virtual COM port to `udev.rules`

### DIFF
--- a/platformio/assets/system/99-platformio-udev.rules
+++ b/platformio/assets/system/99-platformio-udev.rules
@@ -171,3 +171,6 @@ ATTRS{product}=="*CMSIS-DAP*", MODE="0666", ENV{ID_MM_DEVICE_IGNORE}="1", ENV{ID
 
 # Atmel AVR Dragon
 ATTRS{idVendor}=="03eb", ATTRS{idProduct}=="2107", MODE="0666", ENV{ID_MM_DEVICE_IGNORE}="1", ENV{ID_MM_PORT_IGNORE}="1"
+
+# Espressif USB JTAG/serial debug unit
+ATTRS{idVendor}=="303a", ATTR{idProduct}=="1001", MODE="0666", ENV{ID_MM_DEVICE_IGNORE}="1", ENV{ID_MM_PORT_IGNORE}="1"

--- a/platformio/assets/system/99-platformio-udev.rules
+++ b/platformio/assets/system/99-platformio-udev.rules
@@ -85,6 +85,8 @@ ATTRS{idVendor}=="2e8a", ATTRS{idProduct}=="[01]*", MODE:="0666", ENV{ID_MM_DEVI
 # AIR32F103
 ATTRS{idVendor}=="0d28", ATTRS{idProduct}=="0204", MODE="0666", ENV{ID_MM_DEVICE_IGNORE}="1", ENV{ID_MM_PORT_IGNORE}="1"
 
+# STM32 virtual COM port
+ATTRS{idVendor}=="0483", ATTRS{idProduct}=="5740", MODE="0666", ENV{ID_MM_DEVICE_IGNORE}="1", ENV{ID_MM_PORT_IGNORE}="1"
 
 #
 # Debuggers


### PR DESCRIPTION
In case of interfacing an STM32 chip as USB-CDC device. This enabled me to treat the USB-port of the Electrosmith Daisy Seed as a normal `/dev/ttyACMx` serial interface. Other use-cases are not known to me, you guys decide if that is a worthy addition.