### PR TITLE
Remove unused build output buffer

### DIFF
--- a/platformio/proc.py
+++ b/platformio/proc.py
@@ -69,6 +69,8 @@ class BuildAsyncPipe(AsyncPipeBase):
         print_immediately = False
 
         for char in iter(lambda: self._pipe_reader.read(1), ""):
+            # self._buffer += char
+            
             if line and char.strip() and line[-3:] == (char * 3):
                 print_immediately = True
 

--- a/platformio/proc.py
+++ b/platformio/proc.py
@@ -70,7 +70,7 @@ class BuildAsyncPipe(AsyncPipeBase):
 
         for char in iter(lambda: self._pipe_reader.read(1), ""):
             # self._buffer += char
-            
+
             if line and char.strip() and line[-3:] == (char * 3):
                 print_immediately = True
 

--- a/platformio/proc.py
+++ b/platformio/proc.py
@@ -69,8 +69,6 @@ class BuildAsyncPipe(AsyncPipeBase):
         print_immediately = False
 
         for char in iter(lambda: self._pipe_reader.read(1), ""):
-            self._buffer += char
-
             if line and char.strip() and line[-3:] == (char * 3):
                 print_immediately = True
 


### PR DESCRIPTION
In verbose mode, output from the build command was constantly being appended to an unused buffer, character by character. Even a simple project using ESP-IDF would generate over 5 million append operations, which is quite slow because the backing memory for this buffer has to be constantly reallocated.

The actual buffer that's used is the local `line` variable. An alternative fix would be to remove `line` and use `self._buffer` instead, so that the `get_buffer()` method will return the buffer contents.

| | Time to compile |
| --- | --- |
| Baseline (non-verbose) | 22.97 seconds |
| Before patch (verbose) | **1722.01 seconds** |
| After patch (verbose) | 24.23 seconds |

Fixes #4783.