### PR TITLE
Allow Starlette 0.35.1

### DIFF
--- a/platformio/pipdeps.py
+++ b/platformio/pipdeps.py
@@ -35,7 +35,7 @@ def get_pip_dependencies():
     home = [
         # PIO Home requirements
         "ajsonrpc == 1.2.*",
-        "starlette >=0.19, <0.35",
+        "starlette >=0.19, <0.36",
         "uvicorn %s" % ("== 0.16.0" if PY36 else ">=0.16, <0.26"),
         "wsproto == 1.*",
     ]


### PR DESCRIPTION
I need to loosen the dependency bound for the package in the development version of Fedora Linux, so I’m offering the change as a PR.

I had a hard time validating this, as some tests were failing in my environment before this commit, but I don’t expect there should be anything disruptive here.

https://github.com/encode/starlette/releases