### PR TITLE
Fix symlink package spec validation

### DIFF
--- a/platformio/package/manager/base.py
+++ b/platformio/package/manager/base.py
@@ -281,9 +281,16 @@ class BasePackageManager(  # pylint: disable=too-many-public-methods,too-many-in
         # external "URL" mismatch
         if spec.external:
             # local folder mismatch
-            if os.path.abspath(spec.uri) == os.path.abspath(pkg.path) or (
-                spec.uri.startswith("file://")
-                and os.path.abspath(pkg.path) == os.path.abspath(spec.uri[7:])
+            if (
+                os.path.abspath(spec.uri) == os.path.abspath(pkg.path)
+                or (
+                    spec.uri.startswith("file://")
+                    and os.path.abspath(pkg.path) == os.path.abspath(spec.uri[7:])
+                )
+                or (
+                    spec.uri.startswith("symlink://")
+                    and os.path.abspath(pkg.path) == os.path.abspath(spec.uri[10:])
+                )
             ):
                 return True
             if spec.uri != pkg.metadata.spec.uri:


### PR DESCRIPTION
While developing a library package, I tried to use a `symlink://` specification in my test application to point to my library's development checkout.  Unfortunately this seemed to cause a number of issues:
- The symlinked package did not appear in `platformio pkg list`
- Every build would "re-install" the symlink package
- As a result of the "reinstallation", the PlatformIO VSCode plugin would try to re-configure itself mid-build, causing a number of failures as it deleted some of the working build folders

I traced this to the installed symlink package not matching its own pkg spec in `package/manager/base.py`.   It looks like it just needed the same `abspath()` check as a `file://` specification.