### PR TITLE
Improve memory exhaustion warnings/errors

### DIFF
--- a/platformio/builder/tools/pioupload.py
+++ b/platformio/builder/tools/pioupload.py
@@ -218,16 +218,20 @@ def CheckUploadSize(_, target, source, env):
     if int(ARGUMENTS.get("PIOVERBOSE", 0)):
         print(output)
 
+    memory_exceeded = False
     if data_max_size and data_size > data_max_size:
+        memory_exceeded = True
         sys.stderr.write(
             "Warning! The data size (%d bytes) is greater "
             "than maximum allowed (%s bytes)\n" % (data_size, data_max_size)
         )
     if program_size > program_max_size:
+        memory_exceeded = True
         sys.stderr.write(
             "Error: The program size (%d bytes) is greater "
             "than maximum allowed (%s bytes)\n" % (program_size, program_max_size)
         )
+    if memory_exceeded:
         env.Exit(1)
 
 

--- a/platformio/builder/tools/pioupload.py
+++ b/platformio/builder/tools/pioupload.py
@@ -219,17 +219,24 @@ def CheckUploadSize(_, target, source, env):
         print(output)
 
     memory_exceeded = False
+    ram_free = ARGUMENTS.get("RAMFREE", 0)
     if data_max_size and data_size > data_max_size:
         memory_exceeded = True
         sys.stderr.write(
             "Error: Pre-allocated RAM usage (%d bytes) is greater "
-            "than RAM available (%s bytes)\n" % (data_size, data_max_size)
+            "than RAM available (%d bytes)\n" % (data_size, data_max_size)
+        )
+    elif ramfree and data_max_size and data_size + ram_free > data_max_size:
+        memory_exceeded = True
+        sys.stderr.write(
+            "Error: Pre-allocated RAM usage (%d bytes of %d total bytes) results in "
+            "less RAM available than minimum required (%d bytes)\n" % (data_size, data_max_size, ram_free)
         )
     if program_size > program_max_size:
         memory_exceeded = True
         sys.stderr.write(
             "Error: Flash usage (%d bytes) is greater "
-            "than Flash available (%s bytes)\n" % (program_size, program_max_size)
+            "than Flash available (%d bytes)\n" % (program_size, program_max_size)
         )
     if memory_exceeded:
         env.Exit(1)

--- a/platformio/builder/tools/pioupload.py
+++ b/platformio/builder/tools/pioupload.py
@@ -222,14 +222,14 @@ def CheckUploadSize(_, target, source, env):
     if data_max_size and data_size > data_max_size:
         memory_exceeded = True
         sys.stderr.write(
-            "Warning! The data size (%d bytes) is greater "
-            "than maximum allowed (%s bytes)\n" % (data_size, data_max_size)
+            "Error: Pre-allocated RAM usage (%d bytes) is greater "
+            "than RAM available (%s bytes)\n" % (data_size, data_max_size)
         )
     if program_size > program_max_size:
         memory_exceeded = True
         sys.stderr.write(
-            "Error: The program size (%d bytes) is greater "
-            "than maximum allowed (%s bytes)\n" % (program_size, program_max_size)
+            "Error: Flash usage (%d bytes) is greater "
+            "than Flash available (%s bytes)\n" % (program_size, program_max_size)
         )
     if memory_exceeded:
         env.Exit(1)

--- a/platformio/builder/tools/pioupload.py
+++ b/platformio/builder/tools/pioupload.py
@@ -230,7 +230,7 @@ def CheckUploadSize(_, target, source, env):
         memory_exceeded = True
         sys.stderr.write(
             "Error: Pre-allocated RAM usage (%d bytes of %d total bytes) results in "
-            "less RAM available than minimum required (%d bytes)\n" % (data_size, data_max_size, ram_free)
+            "less RAM remaining than minimum required (%d bytes)\n" % (data_size, data_max_size, ram_free)
         )
     if program_size > program_max_size:
         memory_exceeded = True

--- a/platformio/platform/_run.py
+++ b/platformio/platform/_run.py
@@ -80,6 +80,7 @@ class PlatformRunMixin:
             os.path.join(fs.get_source_dir(), "builder", "main.py"),
         ]
         args.append("PIOVERBOSE=%d" % int(self.verbose))
+        args.append("RAMFREE=%d" % int(self.ramfree))
         # pylint: disable=protected-access
         args.append("ISATTY=%d" % int(click._compat.isatty(sys.stdout)))
         # encode and append variables

--- a/platformio/run/cli.py
+++ b/platformio/run/cli.py
@@ -75,6 +75,17 @@ except NotImplementedError:
 @click.option("--list-targets", is_flag=True)
 @click.option("-s", "--silent", is_flag=True)
 @click.option("-v", "--verbose", is_flag=True)
+@click.option(
+    "-r",
+    "--ramfree",
+    type=int,
+    default=0,
+    help=(
+        "Specify the minimum number of bytes of RAM that must remain after pre-allocation. "
+        "Insufficient free ram can lead to crashes, reboots etc. when memory "
+        "becomes exhausted during dynamic allocation or stack usage."
+    ),
+)
 @click.pass_context
 def cli(
     ctx,
@@ -90,6 +101,7 @@ def cli(
     list_targets,
     silent,
     verbose,
+    ramfree,
 ):
     app.set_session_var("custom_project_conf", project_conf)
 
@@ -154,6 +166,7 @@ def cli(
                     is_test_running,
                     silent,
                     verbose,
+                    ramfree,
                 )
             )
         command_failed = any(r.get("succeeded") is False for r in results)
@@ -186,6 +199,7 @@ def process_env(
     is_test_running,
     silent,
     verbose,
+    ramfree,
 ):
     if not is_test_running and not silent:
         print_processing_header(name, config, verbose)
@@ -205,6 +219,7 @@ def process_env(
             program_args,
             silent,
             verbose,
+            ramfree,
         ).process()
 
     if result["succeeded"] and "monitor" in targets and "nobuild" not in targets:


### PR DESCRIPTION
Firmware typically pre-allocates RAM memory where it can, and then remaining memory is used for dynamic allocation and the stack.

Currently excessive RAM usage is only a warning and not an error, which means that you are not alerted by a build failure but instead need to scan the PIO RUN output to see whether RAM usage is too high for the build. But in any case, typically firmware requires a certain amount of RAM to be available after the pre-allocation that is calculated by PIO, and you need to alerted when the remaining memory falls below this required free-memory amount.

This PR does two things:

1. RAM pre-allocation greater than available memory is now treated as an error and not a warning.
2. It introduces a RAMFREE option that can be used to define a minimum amount of memory required to remain free (for dynamic allocation and stack usage) after pre-allocation, with an error if pre-allocation results in less than this amount free.