### PR TITLE
Fix Clang detection

### DIFF
--- a/platformio/builder/tools/piomisc.py
+++ b/platformio/builder/tools/piomisc.py
@@ -23,6 +23,8 @@ from platformio.proc import exec_command
 def GetCompilerType(env):
     if env.subst("$CC").endswith("-gcc"):
         return "gcc"
+    if os.path.basename(env.subst("$CC")) == "clang":
+        return "clang"
     try:
         sysenv = os.environ.copy()
         sysenv["PATH"] = str(env["ENV"]["PATH"])
@@ -32,8 +34,6 @@ def GetCompilerType(env):
     if result["returncode"] != 0:
         return None
     output = "".join([result["out"], result["err"]]).lower()
-    if "clang" in output and "LLVM" in output:
-        return "clang"
     if "gcc" in output:
         return "gcc"
     return None


### PR DESCRIPTION
The previous way that Clang was detected was not working: first the string is cast to lowercase, and then there's a check for "LLVM" (uppercase) which of course will never work. This change removes that useless check and replaces it with a check for the filename (like is already the case for GCC) so that Clang is detected in at least some cases.

The reason this is necessary is because I'm trying to add a WebAssembly target which uses Clang, and which uses wasm-ld for linking. Sadly, PlatformIO adds `-Wl,--start-group` and `-Wl,--end-group` which aren't supported by wasm-ld. But they shouldn't have been added anyway: they were only added because the compiler was (incorrectly) detected as GCC.

Sidenote: the reason Clang is detected as GCC is because `$CC -v` (which expands to `clang -v`) outputs the following on my system:

    clang version 17.0.6 (Fedora 17.0.6-2.fc39)
    Target: aarch64-redhat-linux-gnu
    Thread model: posix
    InstalledDir: /usr/bin
    Found candidate GCC installation: /usr/bin/../lib/gcc/aarch64-redhat-linux/13
    Selected GCC installation: /usr/bin/../lib/gcc/aarch64-redhat-linux/13
    Candidate multilib: .;@m64
    Selected multilib: .;@m64

This contains the string 'GCC' even though it is Clang. Perhaps the correct command would be `$CC --version`? It outputs the following instead:

    clang version 17.0.6 (Fedora 17.0.6-2.fc39)
    Target: aarch64-redhat-linux-gnu
    Thread model: posix
    InstalledDir: /usr/bin

There is no 'gcc' string here!
The GCC version of this (`gcc --version`) also outputs something more reasonable:

    gcc (GCC) 13.2.1 20240316 (Red Hat 13.2.1-7)
    Copyright (C) 2023 Free Software Foundation, Inc.
    This is free software; see the source for copying conditions.  There is NO
    warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.