### PR TITLE
Add `pio run -t compiledbtc` option

### DIFF
--- a/platformio/builder/main.py
+++ b/platformio/builder/main.py
@@ -148,7 +148,7 @@ if not int(ARGUMENTS.get("PIOVERBOSE", 0)):
     click.echo("Verbose mode can be enabled via `-v, --verbose` option")
 
 # Dynamically load dependent tools
-if "compiledb" in COMMAND_LINE_TARGETS:
+if "compiledb" or "compiledbtc" in COMMAND_LINE_TARGETS:
     env.Tool("compilation_db")
 
 if not os.path.isdir(env.subst("$BUILD_DIR")):
@@ -194,6 +194,9 @@ if env.get("SIZETOOL") and not (
 
 if "compiledb" in COMMAND_LINE_TARGETS:
     env.Alias("compiledb", env.CompilationDatabase("$COMPILATIONDB_PATH"))
+
+if "compiledbtc" in COMMAND_LINE_TARGETS:
+    env.Alias("compiledbtc", env.CompilationDatabase("$COMPILATIONDB_PATH"))
 
 # Print configured protocols
 env.AddPreAction(

--- a/platformio/builder/tools/piolib.py
+++ b/platformio/builder/tools/piolib.py
@@ -497,6 +497,7 @@ class LibBuilderBase:
 
         self.env.PrependUnique(CPPPATH=self.get_include_dirs())
         self.env.ProcessCompileDbToolchainOption()
+        self.env.ProcessCompileDbIncludeToolchainOption()
 
         if self.lib_ldf_mode == "off":
             for lb in self.env.GetLibBuilders():

--- a/platformio/builder/tools/piomaxlen.py
+++ b/platformio/builder/tools/piomaxlen.py
@@ -70,7 +70,7 @@ def _file_long_data(env, data):
 
 
 def exists(env):
-    return "compiledb" not in COMMAND_LINE_TARGETS and not env.IsIntegrationDump()
+    return "compiledb" and "compiledbtc" not in COMMAND_LINE_TARGETS and not env.IsIntegrationDump()
 
 
 def generate(env):


### PR DESCRIPTION
Option to generate compile_commands.json with including toolchain paths.

A replacement for having to create pre build script with 'COMPILATIONDB_INCLUDE_TOOLCHAIN=True'

This addresses issue #4769 