### PR TITLE
allow manual override of system type

### DIFF
--- a/platformio/util.py
+++ b/platformio/util.py
@@ -137,11 +137,11 @@ def singleton(cls):
 
 
 def get_systype():
-    # allow manual override, eg. for 
+    # allow manual override, eg. for
     # windows on arm64 systems with emulated x86
     if "PLATFORMIO_SYSTEM_TYPE" in os.environ:
         return os.environ.get("PLATFORMIO_SYSTEM_TYPE")
-    
+
     system = platform.system().lower()
     arch = platform.machine().lower()
     if system == "windows":

--- a/platformio/util.py
+++ b/platformio/util.py
@@ -15,6 +15,7 @@
 import datetime
 import functools
 import math
+import os
 import platform
 import re
 import shutil
@@ -136,6 +137,11 @@ def singleton(cls):
 
 
 def get_systype():
+    # allow manual override, eg. for 
+    # windows on arm64 systems with emulated x86
+    if "PLATFORMIO_SYSTEM_TYPE" in os.environ:
+        return os.environ.get("PLATFORMIO_SYSTEM_TYPE")
+    
     system = platform.system().lower()
     arch = platform.machine().lower()
     if system == "windows":


### PR DESCRIPTION
adds a check for `PLATFORMIO_SYSTEM_TYPE` environment variable in the system type detection, so that the system type may be defined manually by the user.

this should help in cases where the detection fails, e.g. on windows on arm64 systems that support x86 emulation. 
in those cases, it'd be ok for platformio to pretend like the system is `windows_x86`, since x86 binaries are executed through emulation.

see https://community.platformio.org/t/windows-on-arm64-problem-installing-xtensa-toolchain/25497 for more details.