### PR TITLE
Allow Starlette 0.38.1

### DIFF
--- a/platformio/dependencies.py
+++ b/platformio/dependencies.py
@@ -44,7 +44,7 @@ def get_pip_dependencies():
     home = [
         # PIO Home requirements
         "ajsonrpc == 1.2.*",
-        "starlette >=0.19, <0.38",
+        "starlette >=0.19, <0.39",
         "uvicorn %s" % ("== 0.16.0" if PY36 else ">=0.16, <0.31"),
         "wsproto == 1.*",
     ]


### PR DESCRIPTION
I need to loosen the dependency bound for the package in the development (Rawhide/F41) and latest stable (F40) versions of Fedora Linux, so I’m offering the change as a PR.

https://github.com/encode/starlette/releases/tag/0.38.0

-----

## Added

- Allow use of `memoryview` in `StreamingResponse` and `Response`
- Send 404 instead of 500 when filename requested is too long on `StaticFiles`

### Changed

- Fail fast on invalid `Jinja2Template` instantiation parameters
- Check endpoint handler is async only once

### Fixed

- Add proper synchronization to `WebSocketTestSession`

-----

I tested this with `tox -e testcore` and did not observe any regressions.