### PR TITLE
Fix can't match the last+on some boards.

### DIFF
--- a/platformio/project/config.py
+++ b/platformio/project/config.py
@@ -41,7 +41,7 @@ CONFIG_HEADER = """
 
 
 class ProjectConfigBase:
-    ENVNAME_RE = re.compile(r"^[a-z\d\_\-]+$", flags=re.I)
+    ENVNAME_RE = re.compile(r"^[a-z\d\_\-]+(\+)?$", flags=re.I)
     INLINE_COMMENT_RE = re.compile(r"\s+;.*$")
     VARTPL_RE = re.compile(r"\$\{(?:([^\.\}\()]+)\.)?([^\}]+)\}")
 


### PR DESCRIPTION
### Description

This PR addresses an issue where users are unable to use development boards with '+' at the end of their names. The regular expression used for validating board names has been updated to include the '+' character.

[cannot-matched-issue](https://github.com/platformio/platformio-home/issues/8508)

For example, when I use STC89C516RD+, I will get an error, because the old regular expression regards the+at the end as an error.

### Changes Made
- Updated the regular expression in the configuration file to allow '+' at the end of board names.

### Impact
This change will enable users to use development boards with names ending in '+', which was previously not possible.

### Testing
The board name (STC89C516RD+) with "+" at the end has been tested, and it has been accepted without any problems.

Thank you for considering this PR.