### PR TITLE
add support for `tar.xz` tarballs

### DIFF
--- a/platformio/package/meta.py
+++ b/platformio/package/meta.py
@@ -396,7 +396,7 @@ class PackageSpec:  # pylint: disable=too-many-instance-attributes
             parts.path.endswith(".git"),
             # Handle GitHub URL (https://github.com/user/package)
             parts.netloc in ("github.com", "gitlab.com", "bitbucket.com")
-            and not parts.path.endswith((".zip", ".tar.gz")),
+            and not parts.path.endswith((".zip", ".tar.gz", ".tar.xz")),
         ]
         hg_conditions = [
             # Handle Developer Mbed URL

--- a/platformio/package/unpack.py
+++ b/platformio/package/unpack.py
@@ -152,6 +152,7 @@ class FileUnpacker:
         magic_map = {
             b"\x1f\x8b\x08": TARArchiver,
             b"\x42\x5a\x68": TARArchiver,
+            b"\xfd\x37\x7a\x58\x5a\x00": TARArchiver,
             b"\x50\x4b\x03\x04": ZIPArchiver,
         }
         magic_len = max(len(k) for k in magic_map)


### PR DESCRIPTION
currently `zip` and `tar.gz` as compressed source for packages are supported.
This PR adds support for `tar.xz` compressed tarballs. 