### PR TITLE
Allow Starlette 0.40.x

### DIFF
--- a/platformio/dependencies.py
+++ b/platformio/dependencies.py
@@ -43,7 +43,7 @@ def get_pip_dependencies():
     home = [
         # PIO Home requirements
         "ajsonrpc == 1.2.*",
-        "starlette >=0.19, <0.40",
+        "starlette >=0.19, <0.41",
         'uvicorn == 0.16.0; python_version < "3.7"',
         'uvicorn >=0.16, <0.31; python_version >= "3.7"',
         "wsproto == 1.*",


### PR DESCRIPTION
This release of Starlette contains a fix for a security bug:

- GHSA-f96h-pmfr-66vw: https://github.com/encode/starlette/security/advisories/GHSA-f96h-pmfr-66vw
- CVE-2024-47874: https://nvd.nist.gov/vuln/detail/CVE-2024-47874

I tested this with `tox -e testcore` and did not observe any regressions.