### PR TITLE
Allow HTTP 203 as successful response

### DIFF
--- a/platformio/package/download.py
+++ b/platformio/package/download.py
@@ -34,7 +34,7 @@ class FileDownloader:
             url,
             stream=True,
         )
-        if self._http_response.status_code != 200:
+        if self._http_response.status_code not in (200, 203):
             raise PackageException(
                 "Got the unrecognized status code '{0}' when downloaded {1}".format(
                     self._http_response.status_code, url


### PR DESCRIPTION
Fixes downloading library dependencies from Azure Devops repositories.

See https://community.platformio.org/t/error-downloading-installing-git-repositories-from-behind-a-firewall/9524/2?u=maxgerhardt