### PR TITLE
Allow starlette versions through 0.45

### DIFF
--- a/platformio/dependencies.py
+++ b/platformio/dependencies.py
@@ -43,7 +43,7 @@ def get_pip_dependencies():
     home = [
         # PIO Home requirements
         "ajsonrpc == 1.2.*",
-        "starlette >=0.19, <0.43",
+        "starlette >=0.19, <0.46",
         'uvicorn == 0.16.0; python_version < "3.7"',
         'uvicorn >=0.16, <0.35; python_version >= "3.7"',
         "wsproto == 1.*",


### PR DESCRIPTION
I tested this with `tox -e testcore` and did not observe any regressions.

https://github.com/encode/starlette/blob/0.45.0/docs/release-notes.md