### PR TITLE
Allow starlette versions through 0.46

### DIFF
--- a/platformio/dependencies.py
+++ b/platformio/dependencies.py
@@ -42,7 +42,7 @@ def get_pip_dependencies():
     home = [
         # PIO Home requirements
         "ajsonrpc == 1.2.*",
-        "starlette >=0.19, <0.46",
+        "starlette >=0.19, <0.47",
         "uvicorn >=0.16, <0.35",
         "wsproto == 1.*",
     ]


### PR DESCRIPTION
I tested this with `tox -e testcore` and did not observe any regressions.

https://github.com/encode/starlette/blob/0.46.0/docs/release-notes.md