### PR TITLE
fix: compiledb doesn't respect build (un)flags (#5090)

### DIFF
--- a/platformio/builder/tools/piobuild.py
+++ b/platformio/builder/tools/piobuild.py
@@ -58,8 +58,8 @@ def GetBuildType(env):
 
 
 def BuildProgram(env):
-    env.ProcessCompileDbToolchainOption()
     env.ProcessProgramDeps()
+    env.ProcessCompileDbToolchainOption()
     env.ProcessProjectDeps()
 
     # append into the beginning a main LD script


### PR DESCRIPTION
Related to
 - https://github.com/platformio/platformio-core/issues/5090
 - https://github.com/platformio/platformio-core/issues/4998

This is an attempt to fix the issue of the `compiledb` subcommand not respecting the `build_flags` and `build_unflags` in platformio.ini.