### PR TITLE
Option to disable udev rules check

### DIFF
--- a/platformio/app.py
+++ b/platformio/app.py
@@ -26,6 +26,7 @@ from platformio.compat import IS_WINDOWS, hashlib_encode_data
 from platformio.package.lockfile import LockFile
 from platformio.project.config import ProjectConfig
 from platformio.project.helpers import get_default_projects_dir
+from platformio.util import get_systype
 
 
 def projects_dir_validate(projects_dir):
@@ -64,6 +65,12 @@ DEFAULT_SETTINGS = {
         "value": True,
     },
 }
+
+if "linux" in get_systype():
+    DEFAULT_SETTINGS["disable_udev_rules_check"] = {
+        "description": "Disable udev rules check",
+        "value": False
+    }
 
 SESSION_VARS = {
     "command_ctx": None,

--- a/platformio/fs.py
+++ b/platformio/fs.py
@@ -24,7 +24,7 @@ import sys
 
 import click
 
-from platformio import exception
+from platformio import exception, app
 from platformio.compat import IS_WINDOWS
 
 
@@ -120,7 +120,7 @@ def ensure_udev_rules():
                 result.add(line)
         return result
 
-    if "linux" not in get_systype():
+    if "linux" not in get_systype() or app.get_setting("disable_udev_rules_check"):
         return None
     installed_rules = [
         "/etc/udev/rules.d/99-platformio-udev.rules",


### PR DESCRIPTION
This introduces "disable_udev_rules_check" option in Linux environment.

If set to True, udev rules are not checked. This allows to suppress annoying warnings when 99-platformio-udev.rules is not installed intentionally.

If set to False (default), udev rules are checked as before.