### PR TITLE
Fix: Preserve RFC2217 URLs in SerialPortFinder.find() in "device monitor"

### DIFF
--- a/platformio/device/finder.py
+++ b/platformio/device/finder.py
@@ -133,6 +133,10 @@ class SerialPortFinder:
 
     def find(self, initial_port=None):
         if initial_port:
+            # Treat any URL (contains '://') as a literal port
+            if "://" in initial_port:
+                return initial_port
+            # Otherwise fall back to existing wildcard logic
             if not is_pattern_port(initial_port):
                 return initial_port
             return self.match_serial_port(initial_port)


### PR DESCRIPTION
Fixes platformio/platformio-core#5225
This PR ensures that fully-qualified serial port URLs (e.g., rfc2217://host:port) are not incorrectly processed as wildcard patterns due to characters like ? or *. Instead, such URLs are returned as-is for serial_for_url() usage.
