### PR TITLE
bind symlink:// relative paths to project dir (fix #5201)

### DIFF
--- a/platformio/package/manager/_symlink.py
+++ b/platformio/package/manager/_symlink.py
@@ -18,6 +18,7 @@ import os
 from platformio import fs
 from platformio.package.exception import PackageException
 from platformio.package.meta import PackageItem, PackageSpec
+from platformio.project.config import ProjectConfig
 
 
 class PackageManagerSymlinkMixin:
@@ -25,15 +26,43 @@ class PackageManagerSymlinkMixin:
     def is_symlink(path):
         return path and path.endswith(".pio-link") and os.path.isfile(path)
 
+    # -------- helper: normalize "symlink://..." into an absolute, real path --------
+    @staticmethod
+    def _normalize_symlink_target(uri, cwd_for_rel=None):
+        """
+        Turn a symlink:// URI (which may contain a relative path like ../foo)
+        into an absolute, real (symlinks-resolved) filesystem path.
+
+        If cwd_for_rel is provided, relative paths are resolved against it.
+        Otherwise, resolve against the current project's directory.
+        """
+        prefix = "symlink://"
+        target = uri[len(prefix):] if uri.startswith(prefix) else uri
+
+        # Determine a base directory to resolve relative targets
+        base_dir = cwd_for_rel
+        if not base_dir:
+            try:
+                base_dir = ProjectConfig.get_instance().get("platformio", "project_dir")
+            except Exception:
+                base_dir = os.getcwd()
+
+        # If target is relative, join to the base (project) dir
+        if not os.path.isabs(target):
+            target = os.path.join(base_dir, target)
+
+        # Canonicalize: absolute + follow symlinks
+        return os.path.realpath(os.path.abspath(target))
+
     @classmethod
     def resolve_symlink(cls, path):
         assert cls.is_symlink(path)
         data = fs.load_json(path)
         spec = PackageSpec(**data["spec"])
         assert spec.symlink
-        pkg_dir = spec.uri[10:]
-        if not os.path.isabs(pkg_dir):
-            pkg_dir = os.path.normpath(os.path.join(data["cwd"], pkg_dir))
+
+        pkg_dir = cls._normalize_symlink_target(spec.uri, cwd_for_rel=data.get("cwd"))
+
         return (pkg_dir if os.path.isdir(pkg_dir) else None, spec)
 
     def get_symlinked_package(self, path):
@@ -47,17 +76,24 @@ class PackageManagerSymlinkMixin:
 
     def install_symlink(self, spec):
         assert spec.symlink
-        pkg_dir = spec.uri[10:]
+
+        pkg_dir = self._normalize_symlink_target(spec.uri)
+
         if not os.path.isdir(pkg_dir):
             raise PackageException(
-                f"Can not create a symbolic link for `{pkg_dir}`, not a directory"
+                "Symlink target does not exist or is not a directory: %s" % pkg_dir
             )
-        link_path = os.path.join(
-            self.package_dir,
-            "%s.pio-link" % (spec.name or os.path.basename(os.path.abspath(pkg_dir))),
-        )
+
+        link_name = spec.name or os.path.basename(os.path.abspath(pkg_dir))
+        link_path = os.path.join(self.package_dir, f"{link_name}.pio-link")
+
+        # Persist absolute target in the stored spec so later reads don't depend on CWD
+        spec_dict = spec.as_dict()
+        spec_dict["uri"] = f"symlink://{pkg_dir}"
+
         with open(link_path, mode="w", encoding="utf-8") as fp:
-            json.dump(dict(cwd=os.getcwd(), spec=spec.as_dict()), fp)
+            json.dump(dict(cwd=os.getcwd(), spec=spec_dict), fp)
+
         return self.get_symlinked_package(link_path)
 
     def uninstall_symlink(self, spec):
@@ -67,5 +103,5 @@ class PackageManagerSymlinkMixin:
             if not self.is_symlink(path):
                 continue
             pkg = self.get_symlinked_package(path)
-            if pkg.metadata.spec.uri == spec.uri:
+            if pkg and pkg.metadata and pkg.metadata.spec.uri == spec.uri:
                 os.remove(path)

--- a/platformio/package/manager/_symlink.py.bak
+++ b/platformio/package/manager/_symlink.py.bak
@@ -1,0 +1,71 @@
+# Copyright (c) 2014-present PlatformIO <contact@platformio.org>
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json
+import os
+
+from platformio import fs
+from platformio.package.exception import PackageException
+from platformio.package.meta import PackageItem, PackageSpec
+
+
+class PackageManagerSymlinkMixin:
+    @staticmethod
+    def is_symlink(path):
+        return path and path.endswith(".pio-link") and os.path.isfile(path)
+
+    @classmethod
+    def resolve_symlink(cls, path):
+        assert cls.is_symlink(path)
+        data = fs.load_json(path)
+        spec = PackageSpec(**data["spec"])
+        assert spec.symlink
+        pkg_dir = spec.uri[10:]
+        if not os.path.isabs(pkg_dir):
+            pkg_dir = os.path.normpath(os.path.join(data["cwd"], pkg_dir))
+        return (pkg_dir if os.path.isdir(pkg_dir) else None, spec)
+
+    def get_symlinked_package(self, path):
+        pkg_dir, spec = self.resolve_symlink(path)
+        if not pkg_dir:
+            return None
+        pkg = PackageItem(os.path.realpath(pkg_dir))
+        if not pkg.metadata:
+            pkg.metadata = self.build_metadata(pkg.path, spec)
+        return pkg
+
+    def install_symlink(self, spec):
+        assert spec.symlink
+        pkg_dir = spec.uri[10:]
+        if not os.path.isdir(pkg_dir):
+            raise PackageException(
+                f"Can not create a symbolic link for `{pkg_dir}`, not a directory"
+            )
+        link_path = os.path.join(
+            self.package_dir,
+            "%s.pio-link" % (spec.name or os.path.basename(os.path.abspath(pkg_dir))),
+        )
+        with open(link_path, mode="w", encoding="utf-8") as fp:
+            json.dump(dict(cwd=os.getcwd(), spec=spec.as_dict()), fp)
+        return self.get_symlinked_package(link_path)
+
+    def uninstall_symlink(self, spec):
+        assert spec.symlink
+        for name in os.listdir(self.package_dir):
+            path = os.path.join(self.package_dir, name)
+            if not self.is_symlink(path):
+                continue
+            pkg = self.get_symlinked_package(path)
+            if pkg.metadata.spec.uri == spec.uri:
+                os.remove(path)

--- a/tests/package/test_manager.py
+++ b/tests/package/test_manager.py
@@ -652,3 +652,32 @@ def test_update_without_metadata(isolated_pio_core, tmpdir_factory):
     new_pkg = lm.update(pkg)
     assert len(lm.get_installed()) == 4
     assert new_pkg.metadata.spec.owner == "heman"
+
+def test_install_symlink_relative_parent(tmp_path):
+    # project layout
+    project_dir = tmp_path / "proj"
+    lib_root = tmp_path / "common_libs" / "DemoLibSymlink"
+    (lib_root / "src").mkdir(parents=True)
+    (lib_root / "library.json").write_text('{"name":"DemoLibSymlink","version":"1.0.0"}')
+
+    # storage dir like .pio/libdeps/<env>
+    storage_dir = project_dir / ".pio" / "libdeps" / "env"
+    storage_dir.mkdir(parents=True)
+
+    # prepare LibraryPackageManager
+    from platformio.package.manager.library import LibraryPackageManager
+    from platformio.project.config import ProjectConfig
+    lm = LibraryPackageManager(str(storage_dir))
+
+    # make ProjectConfig point to our project
+    cfg = ProjectConfig.get_instance()
+    cfg.enable_warnings = False
+    cfg.set("platformio", "project_dir", str(project_dir))
+
+    # relative spec (this reproduces the original issue)
+    spec = "DemoLibSymlink=symlink://../common_libs/DemoLibSymlink"
+
+    # install and assert it resolves to the real absolute path
+    pkg = lm.install_from_uri(spec.split("=", 1)[1], spec)
+    import os
+    assert os.path.realpath(pkg.path) == os.path.realpath(str(lib_root))

--- a/tests/package/test_symlink_relative.py
+++ b/tests/package/test_symlink_relative.py
@@ -1,0 +1,30 @@
+import os
+from platformio.package.manager.library import LibraryPackageManager
+from platformio.project.config import ProjectConfig
+
+def test_install_symlink_relative_parent(tmp_path):
+    # project-like layout
+    project_dir = tmp_path / "proj"
+    lib_root = tmp_path / "common_libs" / "DemoLibSymlink"
+    (lib_root / "src").mkdir(parents=True)
+    (lib_root / "library.json").write_text('{"name":"DemoLibSymlink","version":"1.0.0"}')
+
+    # .pio/libdeps/<env> storage
+    storage_dir = project_dir / ".pio" / "libdeps" / "env"
+    storage_dir.mkdir(parents=True)
+
+    # reset singleton + set project_dir
+    ProjectConfig._instances = {}
+    cfg = ProjectConfig.get_instance()
+    cfg.enable_warnings = False
+    if not cfg.has_section("platformio"):
+        cfg.add_section("platformio")
+    cfg.set("platformio", "project_dir", str(project_dir))
+
+    # act: install via relative symlink
+    lm = LibraryPackageManager(str(storage_dir))
+    spec = "DemoLibSymlink=symlink://../common_libs/DemoLibSymlink"
+    pkg = lm.install_from_uri(spec.split("=", 1)[1], spec)
+
+    # assert: resolved to absolute real path of the lib folder
+    assert os.path.realpath(pkg.path) == os.path.realpath(str(lib_root))


### PR DESCRIPTION
# Early-bind `symlink://` relative paths to project dir (fix #5201)

## Summary
Resolve `symlink://` URIs **early** against the project directory, then canonicalize (abspath + realpath). This prevents late-binding to `.pio/libdeps/...` which broke `../` relative paths specified in `platformio.ini`.

Fixes #5201.

---

## Background / Problem
Given a project like:
```
firmware/
  platformio.ini
common_libs/
  DemoLibSymlink/ (library with library.json)
```
and `platformio.ini`:
```ini
[env:uno]
platform = atmelavr
board = uno
framework = arduino
lib_deps =
  DemoLibSymlink=symlink://../common_libs/DemoLibSymlink
```
PlatformIO previously resolved `../common_libs/...` too late, effectively relative to internal storage, causing errors such as “not a directory” or pointing into `~/.platformio/...`.

---

## What’s changed
- **`PackageManagerSymlinkMixin._normalize_symlink_target` (new):**
  - Strip `symlink://`
  - If path is relative, join with `ProjectConfig.get('platformio', 'project_dir')` (fallback to `cwd`)
  - Canonicalize via `os.path.abspath` + `os.path.realpath`
- **`resolve_symlink`** now uses `_normalize_symlink_target` for the stored URI so downstream code operates on a real absolute path.
- **`install_symlink`** normalizes first and persists the absolute target (as `symlink://<abs-path>`) in the `.pio-link` metadata to avoid future CWD dependence.

---

## Tests
Added a focused regression test:
- `tests/package/test_symlink_relative.py::test_install_symlink_relative_parent`  
  Verifies that `symlink://../...` resolves to the correct absolute library directory and installs successfully.

---

## Compatibility
- Absolute `symlink://C:/...` or `symlink:///...` continue to work unchanged.
- Existing `.pio-link` files remain compatible; new ones store an absolute `uri` for robustness.
- Behavior aligns with user expectation that paths in `platformio.ini` are relative to the **project**, not internal storage.

---

## Rationale
Early-binding to the project directory removes ambiguity, fixes incorrect resolutions when `..` is used, and matches the intuitive, documented behavior for project-relative paths.
