### PR TITLE
Fix: exclude nested .vscode directories from package publish

### DIFF
--- a/platformio/package/pack.py
+++ b/platformio/package/pack.py
@@ -49,6 +49,7 @@ class PackagePacker:
         "__*",
         ".DS_Store",
         ".vscode",
+        "**/.vscode/",
         ".cache",
         "**/.cache",
         "**/__pycache__",


### PR DESCRIPTION
Fixes #5160

Problem:
`pio pkg pack/publish` included `.vscode` directories inside subfolders
(e.g. examples), even though the top-level `.vscode` was excluded.

Change:
Added `**/.vscode/` (and normalized `.vscode/` with trailing slash) to
EXCLUDE_DEFAULT. This mirrors `.pio` handling and ensures both top-level
and nested `.vscode` folders are excluded automatically.

Manual test:
- Created test package with examples/blink/.vscode/settings.json
- Before patch: file appeared in tarball
- After patch: `.vscode` excluded from tarball
