### PR TITLE
pkg: user-configurable registry mirror (try mirror first, then fallback) (#5235)

### DIFF
--- a/platformio/app.py
+++ b/platformio/app.py
@@ -63,6 +63,15 @@ DEFAULT_SETTINGS = {
         "description": "Verify the proxy server certificate against the list of supplied CAs",
         "value": True,
     },
+    "registry_mirror": {
+        "description": (
+            "Preferred base URL (mirror) for package downloads. "
+            "If set (or overridden by PLATFORMIO_REGISTRY_MIRROR), "
+            "PlatformIO will try this URL first and fall back to the default registry."
+        ),
+        "value": "",
+        "type": "str",
+    },
 }
 
 SESSION_VARS = {
@@ -211,6 +220,14 @@ def get_setting(name):
 
     return DEFAULT_SETTINGS[name]["value"]
 
+def get_registry_mirror():
+    mirror = os.environ.get("PLATFORMIO_REGISTRY_MIRROR") or get_setting("registry_mirror") or ""
+    mirror = mirror.strip()
+    if not mirror:
+        return ""
+    if not (mirror.startswith("http://") or mirror.startswith("https://")):
+        mirror = "https://" + mirror
+    return mirror.rstrip("/")
 
 def set_setting(name, value):
     with State(lock=True) as state:

--- a/platformio/package/manager/_download.py
+++ b/platformio/package/manager/_download.py
@@ -23,7 +23,28 @@ import click
 from platformio import app, compat, util
 from platformio.package.download import FileDownloader
 from platformio.package.lockfile import LockFile
+from platformio import app  
 
+def _apply_user_mirror(url, filename=None):
+    """
+    If user configured a preferred mirror (env PLATFORMIO_REGISTRY_MIRROR
+    or setting registry_mirror), rewrite ONLY when we have a filename.
+    """
+    try:
+        mirror = app.get_registry_mirror()
+    except Exception:
+        mirror = ""
+    if not mirror:
+        return url
+
+    mirror = mirror.rstrip("/")
+
+    # Only rewrite if caller gave us an explicit artifact filename.
+    # Without it, return the original URL to avoid 404s.
+    if not filename:
+        return url
+
+    return mirror + "/" + str(filename).lstrip("/")
 
 class PackageManagerDownloadMixin:
     DOWNLOAD_CACHE_EXPIRE = 86400 * 30  # keep package in a local cache for 1 month
@@ -55,6 +76,10 @@ class PackageManagerDownloadMixin:
                     os.remove(dl_path)
 
     def download(self, url, checksum=None):
+        # APPLY MIRROR FIX
+        url = _apply_user_mirror(url)
+       
+
         silent = not self.log.isEnabledFor(logging.INFO)
         dl_path = self.compute_download_path(url, checksum or "")
         if os.path.isfile(dl_path):

--- a/platformio/package/manager/_registry.py
+++ b/platformio/package/manager/_registry.py
@@ -16,6 +16,8 @@ import time
 
 import click
 
+import os
+from platformio import app
 from platformio.package.exception import UnknownPackageError
 from platformio.package.meta import PackageSpec
 from platformio.package.version import cast_version_to_semver
@@ -45,8 +47,37 @@ class PackageManagerRegistryMixin:
         pkgfile = self.pick_compatible_pkg_file(version["files"]) if version else None
         if not pkgfile:
             raise UnknownPackageError(spec.humanize())
+        
+        download_url = pkgfile["download_url"]
 
-        for url, checksum in RegistryFileMirrorIterator(pkgfile["download_url"]):
+        # Try a user-configured mirror first (env PLATFORMIO_REGISTRY_MIRROR or setting registry_mirror)
+        try:
+            user_mirror = app.get_registry_mirror()
+        except Exception:
+            user_mirror = ""
+        if user_mirror:
+            filename = os.path.basename(download_url)
+            mirror_url = user_mirror.rstrip("/") + "/" + filename.lstrip("/")
+            try:
+                return self.install_from_uri(
+                    mirror_url,
+                    PackageSpec(
+                        owner=package["owner"]["username"],
+                        id=package["id"],
+                        name=package["name"],
+                    ),
+                    pkgfile.get("checksum") or pkgfile["checksum"]["sha256"],
+                )
+            except Exception as exc:  # pylint: disable=broad-except
+                self.log.warning(
+                    click.style("Warning! Package Mirror: %s" % exc, fg="yellow")
+                )
+                self.log.warning(
+                    click.style("Looking for another mirror...", fg="yellow")
+                )
+
+        # original behavior: try registry-provided mirrors / primary
+        for url, checksum in RegistryFileMirrorIterator(download_url):
             try:
                 return self.install_from_uri(
                     url,

--- a/platformio/package/manager/base.py
+++ b/platformio/package/manager/base.py
@@ -16,6 +16,7 @@ import logging
 import os
 import subprocess
 from datetime import datetime
+from platformio import app
 
 import click
 import semantic_version
@@ -42,6 +43,27 @@ from platformio.package.meta import (
 from platformio.proc import get_pythonexe_path
 from platformio.project.helpers import get_project_cache_dir
 
+def _prepend_user_mirror(candidates, filename=None):
+    """
+    If user configured a preferred mirror (env PLATFORMIO_REGISTRY_MIRROR
+    or setting registry_mirror), prepend it to the candidates list.
+    """
+    mirror = ""
+    try:
+        mirror = app.get_registry_mirror()  # defined in app.py
+    except Exception:
+        pass
+
+    if not mirror:
+        return candidates
+
+    mirror_url = mirror.rstrip("/")
+    if filename:
+        mirror_url = mirror_url + "/" + str(filename).lstrip("/")
+
+    if mirror_url not in candidates:
+        return [mirror_url] + list(candidates)
+    return candidates
 
 class ClickLoggingHandler(logging.Handler):
     def emit(self, record):


### PR DESCRIPTION
Adds a user-configurable mirror for package downloads.

- New setting: `registry_mirror` (env override: `PLATFORMIO_REGISTRY_MIRROR`)
- _registry.py: prepend user mirror (using artifact filename), then normal mirrors
- _download.py: safe no-op unless filename is provided (prevents bogus paths)
- No behavior change when unset; automatic fallback preserved

Fixes #5235.
