### PR TITLE
Builder tweak to improve Mbed CE support

### DIFF
--- a/platformio/builder/tools/piobuild.py
+++ b/platformio/builder/tools/piobuild.py
@@ -75,16 +75,13 @@ def BuildProgram(env):
         env.Prepend(_LIBFLAGS="-Wl,--start-group ")
         env.Append(_LIBFLAGS=" -Wl,--end-group")
 
-    # PIO_FRAMEWORK_APPEND_OBJS can be set by the framework to add additional objects (and static libraries)
-    # into the link command for the application.
-    program_objects = env["PIOBUILDFILES"] + env["PIO_EXTRA_APP_OBJS"]
-    program = env.Program(env.subst("$PROGPATH"), program_objects)
+    program = env.Program(env.subst("$PROGPATH"), env["PIOBUILDFILES"])
     env.Replace(PIOMAINPROG=program)
 
     # PIO_EXTRA_APP_SOURCE_DEPS can be set to cause all application objects to depend on the given path(s).
     app_source_deps = env.get("PIO_EXTRA_APP_SOURCE_DEPS", [])
     for dep in app_source_deps:
-        for prog_obj in program_objects:
+        for prog_obj in env["PIOBUILDFILES"]:
             env.Depends(prog_obj, dep)
 
     AlwaysBuild(

--- a/platformio/builder/tools/piobuild.py
+++ b/platformio/builder/tools/piobuild.py
@@ -77,7 +77,7 @@ def BuildProgram(env):
 
     # PIO_FRAMEWORK_APPEND_OBJS can be set by the framework to add additional objects (and static libraries)
     # into the link command for the application.
-    program_objects = env["PIOBUILDFILES"] + env["PIO_FRAMEWORK_APPEND_OBJS"]
+    program_objects = env["PIOBUILDFILES"] + env["PIO_EXTRA_APP_OBJS"]
     program = env.Program(env.subst("$PROGPATH"), program_objects)
     env.Replace(PIOMAINPROG=program)
 

--- a/platformio/builder/tools/piobuild.py
+++ b/platformio/builder/tools/piobuild.py
@@ -75,8 +75,17 @@ def BuildProgram(env):
         env.Prepend(_LIBFLAGS="-Wl,--start-group ")
         env.Append(_LIBFLAGS=" -Wl,--end-group")
 
-    program = env.Program(env.subst("$PROGPATH"), env["PIOBUILDFILES"])
+    # PIO_FRAMEWORK_APPEND_OBJS can be set by the framework to add additional objects (and static libraries)
+    # into the link command for the application.
+    program_objects = env["PIOBUILDFILES"] + env["PIO_FRAMEWORK_APPEND_OBJS"]
+    program = env.Program(env.subst("$PROGPATH"), program_objects)
     env.Replace(PIOMAINPROG=program)
+
+    # PIO_EXTRA_APP_SOURCE_DEPS can be set to cause all application objects to depend on the given path(s).
+    app_source_deps = env.get("PIO_EXTRA_APP_SOURCE_DEPS", [])
+    for dep in app_source_deps:
+        for prog_obj in program_objects:
+            env.Depends(prog_obj, dep)
 
     AlwaysBuild(
         env.Alias(


### PR DESCRIPTION
Hi! I'm working on adding support for the Mbed CE framework to PlatformIO ([forum thread for context](https://community.platformio.org/t/hi-from-mbed-ce-project/48249)). I've nearly gotten it working, but I have to make two small tweaks to the platformio builder logic to get everything running.

## Tweak 1: PIO_EXTRA_APP_OBJS

Update: This is not needed anymore and is removed in the latest version of the PR.

## Tweak 2: PIO_EXTRA_APP_SOURCE_DEPS 
Mbed CE has a ton of #defines that need to be added for every single source file, and rather than make the compiler command line tens of kilobytes long, we write these out to an include file and then force every source file to include this using the `-include` compiler flag.

The problem is that SCons doesn't seem to consider `-include` when scanning dependencies, so if the header gets modified, the source files that depend on it aren't rebuilt. This is a big issue with Mbed CE because it means that a manual clean would be required after editing the mbed_app.json file rather than things rebuilding automatically.

To fix this problem, I added a new `PIO_EXTRA_APP_SOURCE_DEPS` env var. Every application obj file is made to depend on all files in this list, so the app sources will be recompiled if any of these files are changed. This way, I can set the variable to point to the `-include`-ed header and the dependencies will be handled properly.

P.S. I am still new to PlatformIO so please let me know if there's a better name or location for this functionality and I will happily rework it!