### PR TITLE
Allow starlette versions through 0.48

### DIFF
--- a/platformio/dependencies.py
+++ b/platformio/dependencies.py
@@ -42,7 +42,7 @@ def get_pip_dependencies():
     home = [
         # PIO Home requirements
         "ajsonrpc == 1.2.*",
-        "starlette >=0.19, <0.47",
+        "starlette >=0.19, <0.48",
         "uvicorn >=0.16, <0.35",
         "wsproto == 1.*",
     ]


### PR DESCRIPTION
I tested this with `tox -e testcore` and did not observe any regressions.

https://github.com/encode/starlette/blob/0.48.0/docs/release-notes.md

All of the following tests failed in my environment both before and after this PR:

```
================================== short test summary info ==================================
FAILED tests/commands/test_check.py::test_check_tool_complex_defines_handled - AssertionError: Could not find the package with 'platformio/tool-clangtidy @ ~1.150005.0...
FAILED tests/commands/test_check.py::test_check_individual_flags_passed - AssertionError: Could not find the package with 'platformio/tool-clangtidy @ ~1.150005.0...
FAILED tests/commands/test_check.py::test_check_fails_on_defects_only_with_flag - AssertionError: Could not find the package with 'platformio/tool-clangtidy @ ~1.150005.0...
FAILED tests/commands/test_check.py::test_check_fails_on_defects_only_on_specified_level - AssertionError: Could not find the package with 'platformio/tool-clangtidy @ ~1.150005.0...
FAILED tests/commands/test_check.py::test_check_pvs_studio_free_license - assert 0 != 0
FAILED tests/commands/test_check.py::test_check_pvs_studio_fails_without_license - AssertionError: assert 'failed to perform check' in 'checking native > pvs-studio (platf...
FAILED tests/commands/test_check.py::test_check_embedded_platform_all_tools[cppcheck-stm32cube] - AssertionError: Could not find the package with 'platformio/toolchain-gccarmnoneeabi @ >...
FAILED tests/commands/test_check.py::test_check_embedded_platform_all_tools[clangtidy-arduino] - AssertionError: Could not find the package with 'platformio/tool-clangtidy @ ~1.150005.0...
FAILED tests/commands/test_check.py::test_check_embedded_platform_all_tools[clangtidy-stm32cube] - AssertionError: Could not find the package with 'platformio/toolchain-gccarmnoneeabi @ >...
FAILED tests/commands/test_check.py::test_check_embedded_platform_all_tools[clangtidy-zephyr] - AssertionError: Could not find the package with 'platformio/tool-clangtidy @ ~1.150005.0...
FAILED tests/commands/test_check.py::test_check_embedded_platform_all_tools[pvs-studio-arduino] - AssertionError: Could not find the package with 'platformio/tool-pvs-studio @ ~7.18.0' r...
FAILED tests/commands/test_check.py::test_check_embedded_platform_all_tools[pvs-studio-stm32cube] - AssertionError: Could not find the package with 'platformio/toolchain-gccarmnoneeabi @ >...
FAILED tests/commands/test_check.py::test_check_embedded_platform_all_tools[pvs-studio-zephyr] - AssertionError: Could not find the package with 'platformio/tool-pvs-studio @ ~7.18.0' r...
FAILED tests/commands/test_check.py::test_check_skip_includes_from_packages - AssertionError: Could not find the package with 'platformio/toolchain-gccarmnoneeabi @ >...
FAILED tests/commands/test_check.py::test_check_handles_spaces_in_paths - AssertionError: Could not find the package with 'platformio/tool-clangtidy @ ~1.150005.0...
FAILED tests/commands/test_ci.py::test_ci_boards - AssertionError: 2 => Usage: ci [OPTIONS] [SRC]...
FAILED tests/commands/test_ci.py::test_ci_build_dir - AssertionError: 2 => Usage: ci [OPTIONS] [SRC]...
FAILED tests/commands/test_ci.py::test_ci_keep_build_dir - AssertionError: 2 => Usage: ci [OPTIONS] [SRC]...
FAILED tests/commands/test_ci.py::test_ci_keep_build_dir_single_src_dir - AssertionError: 2 => Usage: ci [OPTIONS] [SRC]...
FAILED tests/commands/test_ci.py::test_ci_project_conf - AssertionError: 2 => Usage: ci [OPTIONS] [SRC]...
FAILED tests/commands/test_test.py::test_calculator_example - FileNotFoundError: [Errno 2] No such file or directory: 'examples/unit-testing/calculator'
FAILED tests/commands/test_test.py::test_list_tests - FileNotFoundError: [Errno 2] No such file or directory: 'examples/unit-testing/calculator'
FAILED tests/commands/test_test.py::test_legacy_unity_custom_transport - AssertionError: 1 => Warning! Ignore unknown configuration option `test_transport` in se...
FAILED tests/commands/test_test.py::test_googletest_framework - FileNotFoundError: [Errno 2] No such file or directory: 'examples/unit-testing/googletest'
FAILED tests/misc/test_misc.py::test_ping_internet_ips - requests.exceptions.ConnectTimeout: HTTPConnectionPool(host='185.199.110.153', port=80):...
================== 25 failed, 196 passed, 16 skipped in 515.79s (0:08:35) ===================
```