### PR TITLE
debugged and fixed a bug

### DIFF
--- a/bugfixed/gdb-mi-fix.patch
+++ b/bugfixed/gdb-mi-fix.patch
@@ -1,0 +1,17 @@
+--- a/platformio/debug/process/gdb.py
++++ b/platformio/debug/process/gdb.py
+@@ -181,3 +181,11 @@
+     def stderr_data_received(self, data):
+         super().stderr_data_received(data)
+         self._handle_error(data)
++        if helpers.is_gdbmi_mode():
++            if is_bytes(data):
++                data = data.decode()
++            data = data.strip()
++            if data:
++                self.stdout_data_received(
++                    helpers.escape_gdbmi_stream("&", data + "\n")
++                )
++            return
++        super().stderr_data_received(data)
++        self._handle_error(data)

--- a/platformio/debug/process/gdb.py
+++ b/platformio/debug/process/gdb.py
@@ -165,6 +165,15 @@ class GDBClientProcess(DebugClientProcess):
         self._target_is_running = True
 
     def stderr_data_received(self, data):
+        if helpers.is_gdbmi_mode():
+            if is_bytes(data):
+                data = data.decode()
+            data = data.strip()
+            if data:
+                self.stdout_data_received(
+                    helpers.escape_gdbmi_stream("&", data + "\n")
+                )
+            return
         super().stderr_data_received(data)
         self._handle_error(data)
 


### PR DESCRIPTION
I have applied a patch to platformio/debug/process/gdb.py that formats stderr from GDB into MI log stream records when running in MI mode. This should resolve the issue with malformed text in the debug output.