### PR TITLE
Update starlette and uvicorn dependencies (upper bounds)

### DIFF
--- a/platformio/dependencies.py
+++ b/platformio/dependencies.py
@@ -42,8 +42,8 @@ def get_pip_dependencies():
     home = [
         # PIO Home requirements
         "ajsonrpc == 1.2.*",
-        "starlette >=0.19, <0.49",
-        "uvicorn >=0.16, <0.37",
+        "starlette >=0.19, <0.50",
+        "uvicorn >=0.16, <0.39",
         "wsproto == 1.*",
     ]
 

--- a/platformio/dependencies.py
+++ b/platformio/dependencies.py
@@ -42,7 +42,7 @@ def get_pip_dependencies():
     home = [
         # PIO Home requirements
         "ajsonrpc == 1.2.*",
-        "starlette >=0.19, <0.50",
+        "starlette >=0.19, <0.51",
         "uvicorn >=0.16, <0.39",
         "wsproto == 1.*",
     ]


### PR DESCRIPTION
I really care about starlette 0.49 (which contains a security fix, https://github.com/Kludex/starlette/security/advisories/GHSA-7f5h-v6xp-fcq8), but these two dependencies have recently been updated jointly, 6cf8b8172feb33fc2cb59b83f3bb29d44db8922f, so I decided to follow the established pattern.

I tested this with `tox -e testcore` and did not observe any regressions.