### PR TITLE
Fix: Handle -U flags with spaces in build_flags

### DIFF
--- a/platformio/builder/tools/piobuild.py
+++ b/platformio/builder/tools/piobuild.py
@@ -240,17 +240,51 @@ def ProcessFlags(env, flags):  # pylint: disable=too-many-branches
 
     # Cancel any previous definition of name, either built in or
     # provided with a -U option // Issue #191
-    undefines = [
-        u
-        for u in env.get("CCFLAGS", [])
-        if isinstance(u, string_types) and u.startswith("-U")
-    ]
+    ccflags = env.get("CCFLAGS", [])
+    undefines = []
+
+    # Handle both "-UMACRO" and "-U MACRO" formats
+    i = 0
+    while i < len(ccflags):
+        item = ccflags[i]
+        if isinstance(item, string_types) and item.startswith("-U"):
+            if len(item) == 2:  # Just "-U" by itself
+                # Next item should be the macro name
+                if i + 1 < len(ccflags):
+                    macro_name = ccflags[i + 1]
+                    undefines.append(("-U", macro_name))
+                    i += 2  # Skip both "-U" and the macro name
+                    continue
+            else:  # "-UMACRONAME" format
+                macro_name = item[2:]
+                undefines.append(item)
+                i += 1
+                continue
+        i += 1
+
     if undefines:
         for undef in undefines:
-            env["CCFLAGS"].remove(undef)
-            if undef[2:] in env["CPPDEFINES"]:
-                env["CPPDEFINES"].remove(undef[2:])
-        env.Append(_CPPDEFFLAGS=" %s" % " ".join(undefines))
+            # Handle both formats
+            if isinstance(undef, tuple):
+                flag, macro_name = undef
+                env["CCFLAGS"].remove(flag)
+                env["CCFLAGS"].remove(macro_name)
+            else:
+                macro_name = undef[2:]
+                env["CCFLAGS"].remove(undef)
+
+            # Remove from CPPDEFINES if it exists
+            if macro_name in env["CPPDEFINES"]:
+                env["CPPDEFINES"].remove(macro_name)
+
+        # Build the -U flags string
+        undef_flags = []
+        for undef in undefines:
+            if isinstance(undef, tuple):
+                undef_flags.append(f"{undef[0]} {undef[1]}")
+            else:
+                undef_flags.append(undef)
+        env.Append(_CPPDEFFLAGS=" %s" % " ".join(undef_flags))
 
 
 def ProcessUnFlags(env, flags):


### PR DESCRIPTION
## Summary

Fixes #5237

When using `-U MACRO` (with space) in `build_flags`, SCons' `ParseFlags()` splits it into two separate items in `CCFLAGS`: `['-U', 'MACRO']`. The previous code only captured `'-U'` and attempted `undef[2:]` which resulted in an empty string.

## Changes

This PR modifies the `ProcessFlags` function in `platformio/builder/tools/piobuild.py` to:

1. **Iterate through CCFLAGS with an index** to detect standalone `-U` flags
2. **Pair `-U` with the following macro name** when they're separate items
3. **Handle both formats**:
   - `-UMACRO` (no space) - already working ✓
   - `-U MACRO` (with space) - now fixed ✓

The solution follows a similar pattern to how SCons handles `-D` flags with spaces.

## Testing

Verified the fix handles:
- Single `-U MACRO` format with space
- Single `-UMACRO` format without space  
- Mixed formats in the same build_flags
- Multiple undefines

## Example

**Before (broken):**
```ini
build_flags = -U LORA_TX_POWER
```
Result: Only `-U` captured, macro name lost

**After (fixed):**
```ini
build_flags = -U LORA_TX_POWER
```
Result: Correctly passes `-U LORA_TX_POWER` to gcc