### PR TITLE
ProjectConfig().to_json() produces object instead of array

### DIFF
--- a/platformio/project/config.py
+++ b/platformio/project/config.py
@@ -531,8 +531,11 @@ class ProjectConfig(ProjectConfigBase, ProjectConfigLintMixin, ProjectConfigDirs
     def as_tuple(self):
         return [(s, self.items(s)) for s in self.sections()]
 
+    def as_dict(self):
+        return {s: self.items(s, as_dict=True) for s in self.sections()}
+
     def to_json(self):
-        return json.dumps(self.as_tuple())
+        return json.dumps(self.as_dict())
 
     def update(self, data, clear=False):
         assert isinstance(data, list)


### PR DESCRIPTION
Change behavior of ProjectConfig().to_json() to produce real object instead of array (with key as index 0 and value as index 1).
Example:
```
platformio project config --json-output:

{
  "env:test": {
    "build_flags": [
      "-D FLG_A",
      "-D FLG_B=1"
    ],
    "monitor_speed": 115200
  },
  "env:test2": {
    "build_flags": [
      "-D FLG_A",
      "-D FLG_B=1"
    ],
    "monitor_speed": 115200
  }
}
```

instead of:
```
[
  [
    "env:test",
    [
      [
        "build_flags",
        [
          "-D FLG_A",
          "-D FLG_B=1"
        ]
      ],
      [
        "monitor_speed",
        115200
      ]
    ]
  ],
  [
    "env:test2",
    [
      [
        "build_flags",
        [
          "-D FLG_A",
          "-D FLG_B=1"
        ]
      ],
      [
        "monitor_speed",
        115200
      ]
    ]
  ]
]
```