### PR TITLE
Fix a breaking change brought by Python 3.14 asyncio

### DIFF
--- a/platformio/debug/cli.py
+++ b/platformio/debug/cli.py
@@ -167,7 +167,13 @@ def _configure(
 
 
 def _run(project_dir, debug_config, client_extra_args):
-    loop = asyncio.ProactorEventLoop() if IS_WINDOWS else asyncio.get_event_loop()
+    if IS_WINDOWS:
+        loop = asyncio.ProactorEventLoop()
+    else:
+        try:
+            loop = asyncio.get_event_loop()
+        except RuntimeError:
+            loop = asyncio.new_event_loop()
     asyncio.set_event_loop(loop)
 
     client = GDBClientProcess(project_dir, debug_config)


### PR DESCRIPTION
Python 3.14 [now returns a `RuntimeError`](https://docs.python.org/3/library/asyncio-eventloop.html#:~:text=Changed%20in%20version%203.14%3A%20Raises%20a%20RuntimeError%20if%20there%20is%20no%20current%20event%20loop.) when `asyncio.get_event_loop()` is called when a loop does not exist. 

This patch creates a loop prior to calling `get_event_loop` so that an error is not thrown and debugging works on versions >3.13.