### PR TITLE
Improve UnknownPackageError message clarity

### DIFF
--- a/platformio/package/exception.py
+++ b/platformio/package/exception.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from platformio import util
 from platformio.exception import UserSideException
 
 
@@ -52,10 +51,7 @@ class MissingPackageManifestError(ManifestException):
 
 
 class UnknownPackageError(PackageException):
-    MESSAGE = (
-        "Could not find the package with '{0}' requirements for your system '%s'"
-        % util.get_systype()
-    )
+    MESSAGE = "Could not find the package with '{0}' requirements"
 
 
 class NotGlobalLibDir(PackageException):

--- a/platformio/package/exception.py
+++ b/platformio/package/exception.py
@@ -54,6 +54,13 @@ class UnknownPackageError(PackageException):
     MESSAGE = "Could not find the package with '{0}' requirements"
 
 
+class IncompatiblePackageError(UnknownPackageError):
+    MESSAGE = (
+        "Could not find a version of the package with '{0}' requirements "
+        "compatible with the '{1}' system"
+    )
+
+
 class NotGlobalLibDir(PackageException):
     MESSAGE = (
         "The `{0}` is not a PlatformIO project.\n\n"

--- a/platformio/package/manager/_registry.py
+++ b/platformio/package/manager/_registry.py
@@ -16,8 +16,8 @@ import time
 
 import click
 
-from platformio.package.exception import UnknownPackageError
-from platformio.package.meta import PackageSpec
+from platformio.package.exception import IncompatiblePackageError, UnknownPackageError
+from platformio.package.meta import PackageSpec, PackageType
 from platformio.package.version import cast_version_to_semver
 from platformio.registry.client import RegistryClient
 from platformio.registry.mirror import RegistryFileMirrorIterator
@@ -44,6 +44,10 @@ class PackageManagerRegistryMixin:
 
         pkgfile = self.pick_compatible_pkg_file(version["files"]) if version else None
         if not pkgfile:
+            if self.pkg_type == PackageType.TOOL:
+                from platformio import util
+
+                raise IncompatiblePackageError(spec.humanize(), util.get_systype())
             raise UnknownPackageError(spec.humanize())
 
         for url, checksum in RegistryFileMirrorIterator(pkgfile["download_url"]):


### PR DESCRIPTION
Fixes #4419

The error message for UnknownPackageError was confusing users by mentioning system architecture, making them think their system was incompatible when the actual issue was simply that the package wasn't found.

Changes:
- Simplified error message to focus on package not found
- Removed unused util import

Testing:
- Code passes pylint with 10/10 score
- Code formatted with black and isort