### PR TITLE
Update 99-platformio-udev.rules

### DIFF
--- a/platformio/assets/system/99-platformio-udev.rules
+++ b/platformio/assets/system/99-platformio-udev.rules
@@ -31,6 +31,9 @@ ATTRS{idVendor}=="10c4", ATTRS{idProduct}=="80a9", MODE:="0666", ENV{ID_MM_DEVIC
 # FT231XS USB UART
 ATTRS{idVendor}=="0403", ATTRS{idProduct}=="6015", MODE:="0666", ENV{ID_MM_DEVICE_IGNORE}="1", ENV{ID_MM_PORT_IGNORE}="1"
 
+# FX2348N USB UART
+ATTRS{idVendor}=="0843", ATTRS{idProduct}=="5740", MODE:="0666", ENV{ID_MM_DEVICE_IGNORE}="1", ENV{ID_MM_PORT_IGNORE}="1"
+
 # Prolific Technology, Inc. PL2303 Serial Port
 ATTRS{idVendor}=="067b", ATTRS{idProduct}=="2303", MODE:="0666", ENV{ID_MM_DEVICE_IGNORE}="1", ENV{ID_MM_PORT_IGNORE}="1"
 


### PR DESCRIPTION
Using an one-more Arduino Uno chinese clone, it use FX2348N chip for USB to Serial communication.

I'm new in linux and open-source contributor, and I spend some times to understand what's wrong.

This is my first pull request in my life :)