### PR TITLE
Allow Starlette 0.51, 0.52

### DIFF
--- a/platformio/dependencies.py
+++ b/platformio/dependencies.py
@@ -42,7 +42,7 @@ def get_pip_dependencies():
     home = [
         # PIO Home requirements
         "ajsonrpc == 1.2.*",
-        "starlette >=0.19, <0.51",
+        "starlette >=0.19, <0.53",
         "uvicorn >=0.16, <0.41",
         "wsproto == 1.*",
     ]


### PR DESCRIPTION
In Starlette [0.51](https://github.com/Kludex/starlette/blob/0.51.0/docs/release-notes.md#0510-january-10-2026), the  warning stacklevel on `DeprecationWarning` for the wsgi module was increased. There should be no impact to platformio-core.