### PR TITLE
Fix: Quote cc_path to handle spaces in microcontroller names

### DIFF
--- a/platformio/check/tools/base.py
+++ b/platformio/check/tools/base.py
@@ -90,7 +90,7 @@ class CheckToolBase:  # pylint: disable=too-many-instance-attributes
         def _extract_defines(language, includes_file):
             build_flags = self.cxx_flags if language == "c++" else self.cc_flags
             defines = []
-            cmd = "echo | %s -x %s %s %s -dM -E -" % (
+            cmd = 'echo | "%s" -x %s %s %s -dM -E -' % (
                 self.cc_path,
                 language,
                 " ".join(


### PR DESCRIPTION
## Description
   Fixes issue where microcontroller names containing spaces (e.g., "Adafruit Feather M0") cause the static code analysis tool to fail.
   
   ## Changes
   - Wrapped `self.cc_path` in quotes in the `_get_toolchain_defines()` method in `platformio/check/tools/base.py`
   - This prevents the shell from incorrectly splitting paths that contain spaces
   
   ## Testing
   - Linting passes (10/10 rating)
   - Existing check tests pass
   
   ## Related Issue
   Fixes #4894