### PR TITLE
Fix: Quote Python path to handle spaces in postinstall scripts

### DIFF
--- a/platformio/package/manager/base.py
+++ b/platformio/package/manager/base.py
@@ -335,7 +335,11 @@ class BasePackageManager(  # pylint: disable=too-many-public-methods,too-many-in
         os.environ["PIO_PYTHON_EXE"] = get_pythonexe_path()
         with fs.cd(pkg.path):
             if os.path.isfile(cmd[0]) and cmd[0].endswith(".py"):
-                cmd = [os.environ["PIO_PYTHON_EXE"]] + cmd
+                python_exe = os.environ["PIO_PYTHON_EXE"]
+                # Quote the path if it contains spaces (Windows compatibility)
+                if " " in python_exe:
+                    python_exe = f'"{python_exe}"'
+                    cmd = [python_exe] + cmd
             subprocess.run(
                 " ".join(cmd) if shell else cmd,
                 cwd=pkg.path,

--- a/platformio/package/manager/base.py
+++ b/platformio/package/manager/base.py
@@ -334,7 +334,7 @@ class BasePackageManager(  # pylint: disable=too-many-public-methods,too-many-in
             cmd = [cmd]
         os.environ["PIO_PYTHON_EXE"] = get_pythonexe_path()
         with fs.cd(pkg.path):
-            if os.path.isfile(cmd[0]) and cmd[0].endswith(".py"):
+            if isinstance(cmd, list) and os.path.isfile(cmd[0]) and cmd[0].endswith(".py"):
                 python_exe = os.environ["PIO_PYTHON_EXE"]
                 # Quote the path if it contains spaces (Windows compatibility)
                 if " " in python_exe:


### PR DESCRIPTION
## Description
Fixes installation failure when Python is installed in a directory containing spaces (e.g., `C:\Program Files\Python37\`).

## Changes
- Modified `call_pkg_script()` in `platformio/package/manager/base.py` to wrap the Python executable path in quotes when it contains spaces
- Added `isinstance(cmd, list)` check before accessing list elements (addresses feedback from #5363)
- This prevents the shell from incorrectly splitting the path during postinstall script execution

## Testing
- Fix follows same pattern as #5351 (spaces in microcontroller names)
- Handles both list and string command formats

## Related Issue
Fixes #5361

## Notes
This is a revised version of #5363 incorporating maintainer feedback.