### PR TITLE
Validation relies on assert, which is stripped in optimized Python mode

### DIFF
--- a/platformio/app.py
+++ b/platformio/app.py
@@ -29,7 +29,8 @@ from platformio.project.helpers import get_default_projects_dir
 
 
 def projects_dir_validate(projects_dir):
-    assert os.path.isdir(projects_dir)
+    if not os.path.isdir(projects_dir):
+        raise ValueError(projects_dir)
     return os.path.abspath(projects_dir)
 
 


### PR DESCRIPTION
## Summary

projects_dir_validate() uses `assert os.path.isdir(projects_dir)`. In production environments running Python with `-O`, asserts are removed, so invalid paths are silently accepted. That bypasses config validation and causes downstream failures in unrelated code paths, making errors harder to diagnose.

## Files changed

- `platformio/app.py` (modified)

## Testing

- Not run in this environment.


Closes #5403