### PR TITLE
Stop closing Arduino serial port at Unity test completion

### DIFF
--- a/platformio/test/runners/unity.py
+++ b/platformio/test/runners/unity.py
@@ -127,7 +127,7 @@ void unityOutputComplete(void) { }
 void unityOutputStart(unsigned long baudrate) { Serial.begin(baudrate); }
 void unityOutputChar(unsigned int c) { Serial.write(c); }
 void unityOutputFlush(void) { Serial.flush(); }
-void unityOutputComplete(void) { Serial.end(); }
+void unityOutputComplete(void) { }
         """,
             language="cpp",
         ),


### PR DESCRIPTION
## Summary

The default Arduino Unity config currently emits `unityOutputComplete()` with `Serial.end()`. On Windows (and especially RP2040/USB CDC targets), this can close the port before the host receives the final lines, cause `Permission denied` on subsequent monitor access, and break automated software-reset/re-run flows. The runner-generated default should not tear down the serial transport at test end.

## Files changed

- `platformio/test/runners/unity.py` (modified)

## Testing

- Not run in this environment.


Closes #5359