### PR TITLE
Scope `build_src_flags` to project source compilation only

### DIFF
--- a/platformio/builder/tools/piobuild.py
+++ b/platformio/builder/tools/piobuild.py
@@ -176,7 +176,9 @@ def ProcessProjectDeps(env):
             env.Exit(1)
 
     if "test" not in env["BUILD_TYPE"] or env.GetProjectOption("test_build_src"):
-        plb.env.BuildSources(
+        src_env = plb.env.Clone()
+        src_env.ProcessFlags(src_env.get("BUILD_SRC_FLAGS"))
+        src_env.BuildSources(
             "$BUILD_SRC_DIR", "$PROJECT_SRC_DIR", env.get("SRC_FILTER")
         )
 


### PR DESCRIPTION
## Summary

The current build flow applies `build_src_flags` too early (on a shared/base construction environment), which leaks those flags into library compilation (`lib_deps`). This breaks third-party libraries when users set strict flags like `-Wpedantic` in `build_src_flags`. The fix is to keep `build_src_flags` isolated and apply them only when compiling files from `$PROJECT_SRC_DIR` (and not to library builders, framework packages, or other dependency compilation units).

## Files changed

- `platformio/builder/tools/piobuild.py` (modified)

## Testing

- Not run in this environment.


Closes #5245