### PR TITLE
Expand conditional LDF scanner include paths to use full compile-time include context

### DIFF
--- a/platformio/builder/tools/piolib.py
+++ b/platformio/builder/tools/piolib.py
@@ -120,6 +120,16 @@ class LibBuilderBase:
 
     _INCLUDE_DIRS_CACHE = None
 
+    def get_conditional_scanner_cpppath(self):
+        cpppath = []
+        for item in self.envorigin.get("CPPPATH", []) + self.env.get("CPPPATH", []):
+            if item not in cpppath:
+                cpppath.append(item)
+        for item in self.get_include_dirs():
+            if item not in cpppath:
+                cpppath.append(item)
+        return cpppath
+
     def __init__(self, env, path, manifest=None, verbose=False):
         self.env = env.Clone()
         self.envorigin = env.Clone()


### PR DESCRIPTION
## Summary

In `deep+`/`chain+`-style LDF modes, dependency resolution currently fails when a macro-gating header (for example `sdkconfig.h`) is not inside the limited scanner roots (`src`, `include`, framework-lib folders). The conditional scanner evaluates `#ifdef` blocks without seeing macro definitions from that external header, so guarded includes (like `ETH.h`) are skipped and the dependency graph is incomplete.

## Files changed

- `platformio/builder/tools/piolib.py` (modified)

## Testing

- Not run in this environment.


Closes #4818