### PR TITLE
Add PLATFORMIO_DISABLE_UPGRADE_CHECK env var

### DIFF
--- a/platformio/maintenance.py
+++ b/platformio/maintenance.py
@@ -42,6 +42,9 @@ def on_cmd_end():
     if PlatformioCLI.in_silence():
         return
 
+    if os.environ.get("PLATFORMIO_DISABLE_UPGRADE_CHECK"):
+        return
+
     try:
         check_platformio_upgrade()
         check_prune_system()


### PR DESCRIPTION
When set, skips the periodic PyPI version check and core package auto-update that runs after every command.

Linux distros manage PlatformIO upgrades through their own package managers, so the runtime check just produces errors or misleading "please run pip install -U" messages. Same story for CI, where you pin versions and don't want surprise upgrades.

```
export PLATFORMIO_DISABLE_UPGRADE_CHECK=1
pio run  # no more PyPI check on exit
```

Ref: #5427