### PR TITLE
run: add -p/--port shortcut to set upload-port and monitor-port simultaneously.

### DIFF
--- a/platformio/run/cli.py
+++ b/platformio/run/cli.py
@@ -45,6 +45,7 @@ DEFAULT_JOB_NUMS = int(os.getenv("PLATFORMIO_RUN_JOBS", SYSTEM_CPU_COUNT))
 @click.option("-t", "--target", multiple=True)
 @click.option("--upload-port")
 @click.option("--monitor-port")
+@click.option("-p", "--port", default=None, help="Shortcut: set both upload-port and monitor-port")
 @click.option(
     "-d",
     "--project-dir",
@@ -84,6 +85,7 @@ def cli(  # pylint: disable=too-many-positional-arguments
     target,
     upload_port,
     monitor_port,
+    port,
     project_dir,
     project_conf,
     jobs,
@@ -93,6 +95,10 @@ def cli(  # pylint: disable=too-many-positional-arguments
     silent,
     verbose,
 ):
+    if port:
+        upload_port = upload_port or port
+        monitor_port = monitor_port or port
+
     app.set_session_var("custom_project_conf", project_conf)
 
     # find project directory on upper level


### PR DESCRIPTION
## Description

### Problem

When developing with multiple devices connected, specifying `--upload-port` does not automatically apply to `--monitor-port`. Users must repeat the same port twice:

```bash
pio run -e M5Atom \
  --upload-port /dev/cu.usbserial-6152FEC7E2 \
  --monitor-port /dev/cu.usbserial-6152FEC7E2
```

Worse, when `--upload-port` is specified but `--monitor-port` is not, PlatformIO still scans **all available serial ports** to find a monitor port. This causes failures when other ports are occupied by different devices:

```
UserSideException: [Errno 35] Could not exclusively lock port /dev/cu.usbserial-75527D1BB6: 
[Errno 35] Resource temporarily unavailable
```

This is counterintuitive — the user has already explicitly told PlatformIO which device to use, but PlatformIO still tries to touch other devices.

### Expected Behavior

When a user specifies `--upload-port`, PlatformIO should:
1. Use that port for uploading 
2. **Default `monitor-port` to the same port** instead of scanning other ports 

### Solution

Add `-p / --port` as a shortcut that sets both `--upload-port` and `--monitor-port` to the same value:

```bash
# Before
pio run -e M5Atom \
  --upload-port /dev/cu.usbserial-6152FEC7E2 \
  --monitor-port /dev/cu.usbserial-6152FEC7E2

# After
pio run -e M5Atom -p /dev/cu.usbserial-6152FEC7E2
```

### Use Case

Multi-device development environment:

```
Computer
├── /dev/cu.usbserial-AAA  ← Device A (uploading to this one)
├── /dev/cu.usbserial-BBB  ← Device B (occupied by another process)
└── /dev/cu.usbserial-CCC  ← Device C (occupied by another process)
```

Currently PlatformIO scans and tries to lock all ports even when the target port is explicitly specified, causing unnecessary errors.