### PR TITLE
Fix incorrect PASSED status in test suite footer (#5183)

### DIFF
--- a/platformio/test/cli.py
+++ b/platformio/test/cli.py
@@ -198,7 +198,7 @@ def print_suite_footer(test_suite):
             (
                 click.style(test_suite.status.name, fg="red", bold=True)
                 if is_error
-                else click.style("PASSED", fg="green", bold=True)
+                else click.style(test_suite.status.name, fg="green", bold=True)
             ),
             test_suite.duration,
         ),


### PR DESCRIPTION
### Fix incorrect "PASSED" status in test suite footer (#5183)

#### Summary

Fixes an issue where the test suite footer incorrectly displayed **"PASSED"** for non-error cases, even when the actual test suite status was different (e.g., containing failed or skipped tests).

#### Root Cause

In `platformio/test/cli.py`, the footer output used a hardcoded `"PASSED"` string for all non-error cases instead of reflecting the actual suite status.

#### Fix

Replaced the hardcoded `"PASSED"` with a dynamic value using:

```python
test_suite.status.name
```

This ensures the footer accurately reflects the real test outcome (`PASSED`, `FAILED`, `SKIPPED`, etc.).

#### Validation

Tested with multiple scenarios:

* All tests passed → footer shows **PASSED**
* Mixed results (passed + failed + skipped) → footer shows **FAILED**
* Only skipped tests → footer shows **SKIPPED**

Example (after fix):

```
uno:mixed_cases [FAILED] Took 2.50 seconds
Total cases: 10 | Passed: 5 | Failed: 3 | Skipped: 2
```

#### Impact

* Improves accuracy of test reporting
* Prevents misleading success indicators
* Aligns CLI output with actual test results

---

Fixes #5183
