### PR TITLE
app: use explicit ValueError instead of assert in projects_dir_validate (fixes #5403)

### DIFF
--- a/platformio/app.py
+++ b/platformio/app.py
@@ -29,7 +29,8 @@ from platformio.project.helpers import get_default_projects_dir
 
 
 def projects_dir_validate(projects_dir):
-    assert os.path.isdir(projects_dir)
+    if not os.path.isdir(projects_dir):
+        raise ValueError("Not a directory: %s" % projects_dir)
     return os.path.abspath(projects_dir)
 
 

--- a/tests/misc/test_app.py
+++ b/tests/misc/test_app.py
@@ -1,0 +1,48 @@
+# Copyright (c) 2014-present PlatformIO <contact@platformio.org>
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for platformio.app validators."""
+
+import os
+
+import pytest
+
+from platformio import app
+
+
+def test_projects_dir_validate_accepts_existing_directory(tmp_path):
+    """A path that points to an existing directory passes through validation."""
+    result = app.projects_dir_validate(str(tmp_path))
+    assert result == os.path.abspath(str(tmp_path))
+
+
+def test_projects_dir_validate_raises_on_nonexistent_path(tmp_path):
+    """
+    Regression for platformio-core#5403: validation used \`assert\` which is
+    stripped by python -O, so invalid paths were silently accepted.
+
+    Use a deliberately bogus subpath under tmp_path so the test is hermetic.
+    """
+    missing = tmp_path / "definitely-does-not-exist"
+    assert not missing.exists()
+    with pytest.raises(ValueError):
+        app.projects_dir_validate(str(missing))
+
+
+def test_projects_dir_validate_raises_on_file_path(tmp_path):
+    """Files are not directories and must be rejected."""
+    a_file = tmp_path / "not_a_dir.txt"
+    a_file.write_text("x")
+    with pytest.raises(ValueError):
+        app.projects_dir_validate(str(a_file))


### PR DESCRIPTION
Fixes #5403.

### The bug

`platformio/app.py:`

```python
def projects_dir_validate(projects_dir):
    assert os.path.isdir(projects_dir)
    return os.path.abspath(projects_dir)
```

Python drops `assert` statements under `-O` (and when the `PYTHONOPTIMIZE`
environment variable is set). On production images and distro packages that run
Python in optimised mode, any string - even a fake path - gets through the
validator untouched. The error then surfaces downstream (e.g. when the projects
directory is later globbed), where it is harder to diagnose as a config issue.

### The fix

Replace the `assert` with an explicit `raise ValueError`. One-line diff:

```diff
 def projects_dir_validate(projects_dir):
-    assert os.path.isdir(projects_dir)
+    if not os.path.isdir(projects_dir):
+        raise ValueError("Not a directory: %s" % projects_dir)
     return os.path.abspath(projects_dir)
```

### Why ValueError

Caller (`sanitize_setting`, platformio/app.py:168) wraps any exception from
validators into `exception.InvalidSettingValue` via `raise ... from exc`. So
the user-facing error path is identical. `ValueError` is idiomatic for
"argument has the correct type but wrong value".

### Tests

Adds `tests/misc/test_app.py` with three cases:

#### Verification (local)

```
python -O -c "from platformio import app; app.projects_dir_validate('/nope')"
# Traceback (most recent call last):
# ...
# ValueError: Not a directory: /nope
```

Also verified that the pre-fix code (replicated in a sandbox) silently returned
an invalid path under `-O`.

### No behavioural regression

- Normal (non-optimised) runs: previously `assert` raised `AssertionError`
  (a subclass of `Exception`) which `sanitize_setting` caught. Now raises
  `ValueError` which it still catches. No user-facing difference.
- Optimised (`-O`) runs: was a silent pass-through. Now correctly raises.

### Related

The CONTRIBUTING.md requires a CLA. I'm filing this as an individual contributor
(@adityachilka1) and will sign the CLA through CLA-assistant when the bot prompts.
