### PR TITLE
Declare pip runtime dependency

### DIFF
--- a/platformio/commands/upgrade.py
+++ b/platformio/commands/upgrade.py
@@ -111,7 +111,6 @@ def upgrade_pip_dependencies(verbose):
             "pip",
             "install",
             "--upgrade",
-            "pip",
             *get_pip_dependencies(),
         ],
         check=True,

--- a/platformio/dependencies.py
+++ b/platformio/dependencies.py
@@ -28,6 +28,7 @@ def get_core_dependencies():
 
 def get_pip_dependencies():
     core = [
+        "pip",
         "bottle == 0.13.*",
         "click >=8.0.4, <8.5, !=8.3",  # click 9.0 removes 'protected_args' attribute
         "colorama",

--- a/tests/misc/test_dependencies.py
+++ b/tests/misc/test_dependencies.py
@@ -1,0 +1,40 @@
+# Copyright (c) 2014-present PlatformIO <contact@platformio.org>
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from platformio.commands import upgrade as cmd_upgrade
+from platformio.dependencies import get_pip_dependencies
+
+
+def test_pip_is_declared_dependency():
+    assert get_pip_dependencies().count("pip") == 1
+
+
+def test_upgrade_pip_dependencies_upgrades_declared_pip_once(monkeypatch):
+    calls = []
+
+    monkeypatch.setattr(cmd_upgrade, "get_pythonexe_path", lambda: "python")
+    monkeypatch.setattr(
+        cmd_upgrade.subprocess,
+        "run",
+        lambda args, **kwargs: calls.append((args, kwargs)),
+    )
+
+    cmd_upgrade.upgrade_pip_dependencies(verbose=False)
+
+    args, kwargs = calls[0]
+    assert args[:5] == ["python", "-m", "pip", "install", "--upgrade"]
+    assert args[5:] == get_pip_dependencies()
+    assert args[5:].count("pip") == 1
+    assert kwargs["check"] is True
+    assert kwargs["stdout"] == cmd_upgrade.subprocess.PIPE


### PR DESCRIPTION
## Summary

- declare `pip` as a PlatformIO Python dependency so pipx/uvx/uv tool environments install it explicitly
- remove the duplicate hard-coded `pip` upgrade target from `upgrade_pip_dependencies()`
- add focused tests for the dependency list and upgrade command construction

## Root cause

PlatformIO invokes `python -m pip` at runtime for tool/Python package installation, but `pip` was not listed in `get_pip_dependencies()`. Isolated runners such as pipx, uvx, and `uv tool install` only install declared dependencies, so those environments can omit the `pip` module and fail with `No module named pip`.

Fixes #5418.
Related to #5305.

## Validation

- `C:\Users\Jam\AppData\Local\mise\installs\uv\0.11.26\uv.exe run --with pytest --with-editable . -- python -m pytest tests/misc/test_dependencies.py`
- `C:\Users\Jam\AppData\Local\mise\installs\uv\0.11.26\uv.exe run --with-editable . -- python -c "import importlib.metadata as md; reqs=md.requires('platformio') or []; print([r for r in reqs if r == 'pip']); print(len(reqs))"`
- `mise exec uv@0.11.26 -- uv run --with pytest --with-editable . -- python -m pytest tests/misc/test_dependencies.py`