### PR TITLE
Add tests for pip runtime dependency (#5418, #5305)

### DIFF
--- a/tests/misc/test_dependencies.py
+++ b/tests/misc/test_dependencies.py
@@ -1,0 +1,40 @@
+# Copyright (c) 2014-present PlatformIO <contact@platformio.org>
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from platformio.commands import upgrade as cmd_upgrade
+from platformio.dependencies import get_pip_dependencies
+
+
+def test_pip_is_declared_dependency():
+    assert get_pip_dependencies().count("pip") == 1
+
+
+def test_upgrade_pip_dependencies_upgrades_declared_pip_once(monkeypatch):
+    calls = []
+
+    monkeypatch.setattr(cmd_upgrade, "get_pythonexe_path", lambda: "python")
+    monkeypatch.setattr(
+        cmd_upgrade.subprocess,
+        "run",
+        lambda args, **kwargs: calls.append((args, kwargs)),
+    )
+
+    cmd_upgrade.upgrade_pip_dependencies(verbose=False)
+
+    args, kwargs = calls[0]
+    assert args[:5] == ["python", "-m", "pip", "install", "--upgrade"]
+    assert args[5:] == get_pip_dependencies()
+    assert args[5:].count("pip") == 1
+    assert kwargs["check"] is True
+    assert kwargs["stdout"] == cmd_upgrade.subprocess.PIPE


### PR DESCRIPTION
### Summary

This is a small follow-up to the `pip` runtime-dependency fix that was merged into `develop` in eb3991e6 (resolving #5418 / #5305 / #5468). That commit applied the code change but did not carry over the tests from #5468, so this PR re-adds them on top of the current `develop`.

### What it adds

`tests/misc/test_dependencies.py` with two focused regression tests:
- `test_pip_is_declared_dependency` — checks that `pip` is declared exactly once in `get_pip_dependencies()`.
- `test_upgrade_pip_dependencies_upgrades_declared_pip_once` — checks that `upgrade_pip_dependencies()` builds the expected `python -m pip install --upgrade …` command with `pip` present exactly once, guarding against a re-introduced duplicate.

### Testing

Both tests pass locally against the current `develop` (6.2.0a3):

```
tests/misc/test_dependencies.py::test_pip_is_declared_dependency PASSED
tests/misc/test_dependencies.py::test_upgrade_pip_dependencies_upgrades_declared_pip_once PASSED
2 passed
```

The second test exercises the exact command construction that `pio upgrade --dev` relies on, confirming `pip` is upgraded once alongside the other core dependencies.

Thanks!
