### PR TITLE
Preserve user .vscode/extensions.json on IDE regeneration (#5473)

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -34,6 +34,7 @@ test-driven methodologies, and modern toolchains for unrivaled success.
 * Fixed an issue where the test suite status was incorrectly hardcoded as PASSED (`issue #5183 <https://github.com/platformio/platformio-core/issues/5183>`_)
 * Fixed an issue where using a relative path with the ``-d, --project-dir`` option caused `pio device monitor <https://docs.platformio.org/en/latest/core/userguide/device/cmd_monitor.html>`__ to fail with a "FileNotFoundError" (`pull #5470 <https://github.com/platformio/platformio-core/pull/5470>`_)
 * Fixed compatibility with ``pipx``- and ``uvx``-managed environments by ensuring the required ``pip`` dependency is available when installing Python-based tool packages (`issue #5305 <https://github.com/platformio/platformio-core/issues/5305>`_)
+* Fixed an issue where regenerating the VSCode integration overwrote an existing ``.vscode/extensions.json``, discarding the user's comments, ordering, and formatting, and silently dropping recommendations when the file contained inline or block comments; the required entries are now inserted in place (`issue #5473 <https://github.com/platformio/platformio-core/issues/5473>`_)
 
 6.1.19 (2026-02-04)
 ~~~~~~~~~~~~~~~~~~~

--- a/platformio/project/integration/generator.py
+++ b/platformio/project/integration/generator.py
@@ -21,6 +21,7 @@ from platformio import fs, util
 from platformio.debug.helpers import get_default_debug_env
 from platformio.proc import where_is_program
 from platformio.project.helpers import load_build_metadata
+from platformio.project.integration import jsonc
 
 
 class ProjectGenerator:
@@ -169,9 +170,48 @@ class ProjectGenerator:
         with open(tpl_path, "r", encoding="utf8") as fp:
             return bottle.template(fp.read(), **tpl_vars)
 
-    @staticmethod
-    def _merge_contents(dst_path, contents):
-        if os.path.basename(dst_path) == ".gitignore" and os.path.isfile(dst_path):
+    # File name -> {JSONC key: [required values]}. For these files an existing
+    # user file is updated in place (missing entries are inserted) instead of
+    # being regenerated, so the user's comments, ordering, and formatting are
+    # preserved.
+    IN_PLACE_MERGE_RULES = {
+        "extensions.json": {
+            "recommendations": ["platformio.platformio-ide"],
+            "unwantedRecommendations": ["ms-vscode.cpptools-extension-pack"],
+        }
+    }
+
+    @classmethod
+    def _merge_contents(cls, dst_path, contents):
+        file_name = os.path.basename(dst_path)
+        if file_name == ".gitignore" and os.path.isfile(dst_path):
             return
+        merge_rules = cls.IN_PLACE_MERGE_RULES.get(file_name)
+        if merge_rules and os.path.isfile(dst_path):
+            if cls._merge_jsonc_in_place(dst_path, merge_rules):
+                return
         with open(dst_path, "w", encoding="utf8") as fp:
             fp.write(contents)
+
+    @staticmethod
+    def _merge_jsonc_in_place(dst_path, merge_rules):
+        """Ensure the required entries exist in an existing JSONC file without
+        touching the user's comments, ordering, or formatting. Only rewrites
+        the file when something was actually inserted. Returns ``True`` when the
+        existing file was handled (and must not be regenerated), ``False`` when
+        it could not be parsed and should fall back to regeneration."""
+        with open(dst_path, "r", encoding="utf8") as fp:
+            original = fp.read()
+        try:
+            updated = original
+            changed = False
+            for key, values in merge_rules.items():
+                updated, key_changed = jsonc.ensure_array_items(updated, key, values)
+                changed = changed or key_changed
+        except ValueError:
+            # Not parseable as JSONC; let the caller regenerate from template.
+            return False
+        if changed:
+            with open(dst_path, "w", encoding="utf8") as fp:
+                fp.write(updated)
+        return True

--- a/platformio/project/integration/jsonc.py
+++ b/platformio/project/integration/jsonc.py
@@ -1,0 +1,183 @@
+# Copyright (c) 2014-present PlatformIO <contact@platformio.org>
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Minimal helpers for working with JSONC (JSON with Comments).
+
+VS Code configuration files such as ``.vscode/extensions.json`` are JSONC:
+regular JSON that additionally allows ``//`` line comments, ``/* */`` block
+comments, and trailing commas. The helpers here let PlatformIO parse those
+files and insert entries *in place* without discarding the user's comments,
+ordering, or formatting.
+"""
+
+import json
+import re
+
+
+def _blank_out(text, blank_strings):
+    """Return a copy of ``text`` with comment characters replaced by spaces so
+    that JSON structure can be located with plain string searches. String
+    literals are left intact unless ``blank_strings`` is set, in which case
+    their contents are blanked too (useful when scanning for structural
+    brackets that must not match a bracket inside a string)."""
+    out = []
+    i = 0
+    length = len(text)
+    in_string = False
+    while i < length:
+        char = text[i]
+        if in_string:
+            if char == "\\" and i + 1 < length:
+                out.append("  " if blank_strings else text[i : i + 2])
+                i += 2
+                continue
+            if char == '"':
+                in_string = False
+                out.append('"')
+            else:
+                out.append(" " if blank_strings else char)
+            i += 1
+            continue
+        if char == '"':
+            in_string = True
+            out.append('"')
+            i += 1
+            continue
+        if char == "/" and i + 1 < length and text[i + 1] == "/":
+            while i < length and text[i] != "\n":
+                out.append(" ")
+                i += 1
+            continue
+        if char == "/" and i + 1 < length and text[i + 1] == "*":
+            while i < length and not (
+                text[i] == "*" and i + 1 < length and text[i + 1] == "/"
+            ):
+                out.append(" ")
+                i += 1
+            for _ in range(min(2, length - i)):  # blank the closing "*/"
+                out.append(" ")
+                i += 1
+            continue
+        out.append(char)
+        i += 1
+    return "".join(out)
+
+
+def loads(text):
+    """Parse a JSONC string (comments and trailing commas allowed)."""
+    without_comments = _blank_out(text, blank_strings=False)
+    without_trailing_commas = re.sub(r",(\s*[}\]])", r"\1", without_comments)
+    return json.loads(without_trailing_commas)
+
+
+def _find_array_span(text, key):
+    """Return the ``(open_bracket_idx, close_bracket_idx)`` of the array value
+    for a top-level ``"key": [ ... ]`` pair, or ``None`` if it is absent."""
+    comments_blanked = _blank_out(text, blank_strings=False)
+    match = re.search(r'"%s"\s*:\s*\[' % re.escape(key), comments_blanked)
+    if not match:
+        return None
+    open_idx = match.end() - 1
+    fully_blanked = _blank_out(text, blank_strings=True)
+    close_idx = fully_blanked.find("]", open_idx + 1)
+    if close_idx == -1:
+        return None
+    return (open_idx, close_idx)
+
+
+def _line_indent(text, idx):
+    line_start = text.rfind("\n", 0, idx) + 1
+    indent = ""
+    for char in text[line_start:idx]:
+        if char in " \t":
+            indent += char
+        else:
+            break
+    return indent
+
+
+def _insert_new_array(text, key, items):
+    """Add a brand-new ``"key": [ ... ]`` block right after the opening brace of
+    the top-level object."""
+    comments_blanked = _blank_out(text, blank_strings=False)
+    brace_idx = comments_blanked.find("{")
+    if brace_idx == -1:
+        raise ValueError("No top-level JSON object found")
+    base_indent = _line_indent(text, brace_idx)
+    key_indent = base_indent + "    "
+    item_indent = key_indent + "    "
+    items_block = "".join('\n%s"%s",' % (item_indent, item) for item in items).rstrip(
+        ","
+    )
+    block = '\n%s"%s": [%s\n%s],' % (key_indent, key, items_block, key_indent)
+    return text[: brace_idx + 1] + block + text[brace_idx + 1 :]
+
+
+def _insert_into_array(text, items, open_idx, close_idx):
+    """Insert ``items`` just before the closing bracket of an existing array,
+    matching the indentation of the array's existing elements."""
+    fully_blanked = _blank_out(text, blank_strings=True)
+
+    # Derive element indentation from the first existing element, otherwise
+    # from the closing bracket's line plus one indent level.
+    item_indent = None
+    for idx in range(open_idx + 1, close_idx):
+        if text[idx - 1] == "\n":
+            cursor = idx
+            while cursor < close_idx and text[cursor] in " \t":
+                cursor += 1
+            if cursor < close_idx and fully_blanked[cursor] == '"':
+                item_indent = text[idx:cursor]
+                break
+    close_indent = _line_indent(text, close_idx)
+    if item_indent is None:
+        item_indent = close_indent + "    "
+
+    # Find the last significant character before the closing bracket.
+    last = close_idx - 1
+    while last > open_idx and fully_blanked[last] in " \t\r\n":
+        last -= 1
+    last_significant = fully_blanked[last]
+
+    addition = ""
+    if last_significant not in ("[", ","):
+        addition += ","
+    addition += "".join('\n%s"%s",' % (item_indent, item) for item in items)
+    addition = addition.rstrip(",")
+
+    tail = ""
+    if last_significant == "[":  # array had no multi-line elements
+        tail = "\n" + close_indent
+
+    return text[: last + 1] + addition + tail + text[last + 1 :]
+
+
+def ensure_array_items(text, key, items):
+    """Ensure every value in ``items`` is present in the JSONC array ``key``.
+
+    Missing values are inserted in place, preserving existing comments,
+    ordering, and formatting. Returns ``(new_text, changed)``. Raises
+    ``ValueError`` if ``text`` is not parseable JSONC.
+    """
+    data = loads(text)
+    if not isinstance(data, dict):
+        raise ValueError("Expected a top-level JSON object")
+    existing = data.get(key, [])
+    missing = [item for item in items if item not in existing]
+    if not missing:
+        return (text, False)
+    span = _find_array_span(text, key)
+    if span is None:
+        return (_insert_new_array(text, key, missing), True)
+    return (_insert_into_array(text, missing, span[0], span[1]), True)

--- a/platformio/project/integration/tpls/vscode/.vscode/extensions.json.tpl
+++ b/platformio/project/integration/tpls/vscode/.vscode/extensions.json.tpl
@@ -1,35 +1,10 @@
-% import json
-% import os
-% import re
-%
-% recommendations = set(["platformio.platformio-ide"])
-% unwantedRecommendations = set(["ms-vscode.cpptools-extension-pack"])
-% previous_json = os.path.join(project_dir, ".vscode", "extensions.json")
-% if os.path.isfile(previous_json):
-%   fp = open(previous_json)
-%   contents = re.sub(r"^\s*//.*$", "", fp.read(), flags=re.M).strip()
-%   fp.close()
-%   if contents:
-%       try:
-%           data = json.loads(contents)
-%           recommendations |= set(data.get("recommendations", []))
-%           unwantedRecommendations |= set(data.get("unwantedRecommendations", []))
-%       except ValueError:
-%           pass
-%       end
-%   end
-% end
 {
     // See http://go.microsoft.com/fwlink/?LinkId=827846
     // for the documentation about the extensions.json format
     "recommendations": [
-% for i, item in enumerate(sorted(recommendations)):
-        "{{ item }}"{{ ("," if (i + 1) < len(recommendations) else "") }}
-% end
+        "platformio.platformio-ide"
     ],
     "unwantedRecommendations": [
-% for i, item in enumerate(sorted(unwantedRecommendations)):
-        "{{ item }}"{{ ("," if (i + 1) < len(unwantedRecommendations) else "") }}
-% end
+        "ms-vscode.cpptools-extension-pack"
     ]
 }

--- a/tests/commands/test_init.py
+++ b/tests/commands/test_init.py
@@ -14,6 +14,7 @@
 
 import json
 import os
+import re
 
 from platformio import fs
 from platformio.commands.boards import cli as cmd_boards
@@ -127,6 +128,79 @@ def test_init_ide_vscode(clirunner, validate_cliresult, tmpdir):
             "framework-arduino-avr"
             in tmpdir.join(".vscode").join("c_cpp_properties.json").read()
         )
+
+
+def test_init_ide_vscode_preserves_extensions_json(
+    clirunner, validate_cliresult, tmpdir
+):
+    with tmpdir.as_cwd():
+        result = clirunner.invoke(
+            project_init_cmd,
+            ["--ide", "vscode", "-b", "uno", "--no-install-dependencies"],
+        )
+        validate_cliresult(result)
+        extensions_json = tmpdir.join(".vscode").join("extensions.json")
+        assert "platformio.platformio-ide" in extensions_json.read()
+
+        # Customize the generated file the way a user would: reorder entries,
+        # add a recommendation, and add both a leading and an inline comment.
+        customized = """{
+    // Recommended for our team
+    "recommendations": [
+        "esbenp.prettier-vscode", // team formatter
+        "platformio.platformio-ide"
+    ],
+    "unwantedRecommendations": [
+        "ms-vscode.cpptools-extension-pack"
+    ]
+}
+"""
+        extensions_json.write(customized)
+
+        # Re-run init (as an index rebuild would). The file must be left exactly
+        # as the user wrote it because all required entries are already present.
+        result = clirunner.invoke(
+            project_init_cmd,
+            ["--ide", "vscode", "-b", "uno", "--no-install-dependencies"],
+        )
+        validate_cliresult(result)
+        assert extensions_json.read() == customized
+
+
+def test_init_ide_vscode_inserts_missing_recommendation(
+    clirunner, validate_cliresult, tmpdir
+):
+    with tmpdir.as_cwd():
+        # Pre-seed a user-authored file WITHOUT the PlatformIO recommendation
+        # and containing an inline comment (which the previous implementation
+        # could not parse, silently dropping the user's entry).
+        vscode_dir = tmpdir.mkdir(".vscode")
+        preexisting = """{
+    "recommendations": [
+        "esbenp.prettier-vscode" // team formatter
+    ]
+}
+"""
+        vscode_dir.join("extensions.json").write(preexisting)
+
+        result = clirunner.invoke(
+            project_init_cmd,
+            ["--ide", "vscode", "-b", "uno", "--no-install-dependencies"],
+        )
+        validate_cliresult(result)
+
+        contents = vscode_dir.join("extensions.json").read()
+        # The user's entry and comment survive...
+        assert "esbenp.prettier-vscode" in contents
+        assert "// team formatter" in contents
+        # ...and PlatformIO's recommendation was inserted in place.
+        data = json.loads(
+            re.sub(r"//.*", "", contents)  # strip line comments for assertion
+        )
+        assert data["recommendations"] == [
+            "esbenp.prettier-vscode",
+            "platformio.platformio-ide",
+        ]
 
 
 def test_init_ide_eclipse(clirunner, validate_cliresult):

--- a/tests/project/test_integration_jsonc.py
+++ b/tests/project/test_integration_jsonc.py
@@ -1,0 +1,181 @@
+# Copyright (c) 2014-present PlatformIO <contact@platformio.org>
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+
+from platformio.project.integration import jsonc
+
+
+def test_loads_plain_json():
+    assert jsonc.loads('{"a": [1, 2]}') == {"a": [1, 2]}
+
+
+def test_loads_line_comments():
+    text = """{
+    // leading comment
+    "recommendations": [
+        "a", // trailing comment
+        "b"
+    ]
+}"""
+    assert jsonc.loads(text) == {"recommendations": ["a", "b"]}
+
+
+def test_loads_block_comments():
+    text = """{
+    /* block
+       comment */
+    "recommendations": ["a", "b"]
+}"""
+    assert jsonc.loads(text) == {"recommendations": ["a", "b"]}
+
+
+def test_loads_trailing_commas():
+    text = """{
+    "recommendations": [
+        "a",
+        "b",
+    ],
+}"""
+    assert jsonc.loads(text) == {"recommendations": ["a", "b"]}
+
+
+def test_loads_preserves_comment_markers_inside_strings():
+    text = '{"url": "http://example.com", "note": "a // b /* c */"}'
+    assert jsonc.loads(text) == {
+        "url": "http://example.com",
+        "note": "a // b /* c */",
+    }
+
+
+def test_loads_invalid_raises():
+    with pytest.raises(ValueError):
+        jsonc.loads("{ not valid }")
+
+
+def test_ensure_no_change_when_present():
+    text = """{
+    "recommendations": [
+        "platformio.platformio-ide"
+    ]
+}"""
+    result, changed = jsonc.ensure_array_items(
+        text, "recommendations", ["platformio.platformio-ide"]
+    )
+    assert changed is False
+    assert result == text
+
+
+def test_ensure_inserts_preserving_inline_comment():
+    text = """{
+    "recommendations": [
+        "esbenp.prettier-vscode" // team formatter
+    ]
+}"""
+    result, changed = jsonc.ensure_array_items(
+        text, "recommendations", ["platformio.platformio-ide"]
+    )
+    assert changed is True
+    # user's entry and comment are preserved
+    assert "esbenp.prettier-vscode" in result
+    assert "// team formatter" in result
+    parsed = jsonc.loads(result)
+    assert parsed["recommendations"] == [
+        "esbenp.prettier-vscode",
+        "platformio.platformio-ide",
+    ]
+
+
+def test_ensure_inserts_preserving_block_comment():
+    text = """{
+    /* our team config */
+    "recommendations": [
+        "esbenp.prettier-vscode"
+    ]
+}"""
+    result, changed = jsonc.ensure_array_items(
+        text, "recommendations", ["platformio.platformio-ide"]
+    )
+    assert changed is True
+    assert "/* our team config */" in result
+    assert jsonc.loads(result)["recommendations"] == [
+        "esbenp.prettier-vscode",
+        "platformio.platformio-ide",
+    ]
+
+
+def test_ensure_into_empty_array():
+    text = '{\n    "recommendations": []\n}'
+    result, changed = jsonc.ensure_array_items(
+        text, "recommendations", ["platformio.platformio-ide"]
+    )
+    assert changed is True
+    assert jsonc.loads(result)["recommendations"] == ["platformio.platformio-ide"]
+
+
+def test_ensure_into_array_with_trailing_comma():
+    text = """{
+    "recommendations": [
+        "esbenp.prettier-vscode",
+    ]
+}"""
+    result, changed = jsonc.ensure_array_items(
+        text, "recommendations", ["platformio.platformio-ide"]
+    )
+    assert changed is True
+    parsed = jsonc.loads(result)
+    assert parsed["recommendations"] == [
+        "esbenp.prettier-vscode",
+        "platformio.platformio-ide",
+    ]
+
+
+def test_ensure_creates_missing_key():
+    text = """{
+    "unwantedRecommendations": [
+        "ms-vscode.cpptools-extension-pack"
+    ]
+}"""
+    result, changed = jsonc.ensure_array_items(
+        text, "recommendations", ["platformio.platformio-ide"]
+    )
+    assert changed is True
+    parsed = jsonc.loads(result)
+    assert parsed["recommendations"] == ["platformio.platformio-ide"]
+    # existing key untouched
+    assert parsed["unwantedRecommendations"] == ["ms-vscode.cpptools-extension-pack"]
+
+
+def test_ensure_only_inserts_missing_items():
+    text = """{
+    "recommendations": [
+        "platformio.platformio-ide"
+    ]
+}"""
+    result, changed = jsonc.ensure_array_items(
+        text,
+        "recommendations",
+        ["platformio.platformio-ide", "esbenp.prettier-vscode"],
+    )
+    assert changed is True
+    parsed = jsonc.loads(result)
+    assert parsed["recommendations"] == [
+        "platformio.platformio-ide",
+        "esbenp.prettier-vscode",
+    ]
+
+
+def test_ensure_invalid_jsonc_raises():
+    with pytest.raises(ValueError):
+        jsonc.ensure_array_items("{ not json }", "recommendations", ["x"])


### PR DESCRIPTION
## Description

Fixes #5473.

Regenerating the VSCode integration (`pio project init --ide vscode`, which the VSCode extension triggers on every IntelliSense index rebuild) **unconditionally overwrote** an existing `.vscode/extensions.json` from a template. This had two consequences:

1. **Loss of user customization / VCS churn.** The file was re-rendered from the template on every rebuild, reverting the user's ordering, formatting, and comments, and rewriting the file even when nothing had semantically changed.
2. **Silent data loss.** The template merged the existing file by stripping comments with `re.sub(r"^\s*//.*$", ...)` (full-line `//` only) and then `json.loads`. An **inline `//`** or **`/* */` block comment** (both valid JSONC, which VSCode supports for this file) left invalid JSON, `json.loads` raised `ValueError`, and `except ValueError: pass` swallowed it — collapsing `recommendations` back to just the PlatformIO default and **deleting the user's own recommendations**.

## Changes

- **New helper `platformio/project/integration/jsonc.py`** — minimal JSONC support: comment/trailing-comma-tolerant `loads()`, and `ensure_array_items()` which inserts missing array entries **in place**, preserving the surrounding comments, ordering, and formatting.
- **`ProjectGenerator._merge_contents`** — for `extensions.json`, when the file already exists the required entries are inserted in place; the file is only rewritten when an entry is actually added. If the existing file cannot be parsed as JSONC, it safely falls back to regenerating from the template. When the file is absent, it is scaffolded from the template as before. Other generated files (`c_cpp_properties.json`, `launch.json`) are unaffected and still regenerate.
- **Template** simplified to a static scaffold (the parse/merge logic now lives in code).
- **Tests** — unit tests for the JSONC helper (comments, block comments, trailing commas, comment markers inside strings, empty arrays, missing keys, no-op when already present, invalid input) and end-to-end `project init --ide vscode` tests covering (a) an existing customized file left byte-for-byte unchanged on re-run and (b) a missing recommendation inserted while the user's inline comment and existing entry survive.
- **HISTORY.rst** entry under 6.2.0.

## Why a hand-rolled JSONC helper instead of a dependency?

The problem is not *parsing* JSONC — it's **editing it in place without destroying the user's comments**. Standard JSONC parsers (`json5`, `pyjson5`, `commentjson`, `hjson`) only parse to a Python object; comments do not survive into the parsed result, so a load → mutate → dump round-trip would reintroduce the exact data loss this PR fixes. Comment-preserving round-trip editing of JSONC has no established Python library (unlike `ruamel.yaml` for YAML). Since a parser dependency wouldn't remove the need for the in-place insertion logic — and PlatformIO keeps its dependency set intentionally small — the helper parses only to *decide* whether an entry is missing, then performs a surgical string insertion into the original text, leaving every other byte untouched. It is pure-Python, has no I/O, and is covered by unit tests. Happy to swap in a maintainer-preferred approach if you'd rather.

## Checklist

- [x] `make before-commit` (codespell, isort, black, pylint) passes on the changed files (pylint 10.00/10)
- [x] Tests added and passing
- [ ] CLA signed
