### PR TITLE
device/monitor: fix pio monitor crash when stdin is a pipe

### DIFF
--- a/platformio/device/monitor/terminal.py
+++ b/platformio/device/monitor/terminal.py
@@ -23,9 +23,37 @@ from serial.tools import miniterm
 from platformio.exception import UserSideException
 
 
+class NonInteractiveConsole(miniterm.ConsoleBase):
+    # `miniterm.Console` unconditionally calls `termios.tcgetattr(stdin)` to
+    # switch the terminal into raw mode, which fails with
+    # "Inappropriate ioctl for device" when stdin isn't a real TTY (e.g. it's
+    # a pipe). Reading single bytes directly from stdin needs no raw mode:
+    # there's no interactive terminal to reconfigure, and plain reads are
+    # exactly what a piped byte stream provides.
+    def __init__(self, exit_character):
+        super().__init__()
+        self.exit_character = exit_character
+
+    def getkey(self):
+        char = sys.stdin.read(1)
+        # EOF on the pipe: report it as the exit character so `writer()`
+        # stops instead of spinning on an empty read forever.
+        return char if char else self.exit_character
+
+
 class Terminal(miniterm.Miniterm):
     def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
+        # `Miniterm.__init__` unconditionally instantiates `miniterm.Console`,
+        # which fails immediately (before this method can react) if stdin
+        # isn't a real TTY. Swap in our TTY-less console *before* calling it
+        # so the crashing constructor never runs in that case.
+        original_console_cls = miniterm.Console
+        if not sys.stdin.isatty():
+            miniterm.Console = lambda: NonInteractiveConsole(chr(0x1D))
+        try:
+            super().__init__(*args, **kwargs)
+        finally:
+            miniterm.Console = original_console_cls
         self.pio_unexpected_exception = None
 
     def reader(self):

--- a/tests/commands/test_device_monitor_terminal.py
+++ b/tests/commands/test_device_monitor_terminal.py
@@ -1,0 +1,86 @@
+# Copyright (c) 2014-present PlatformIO <contact@platformio.org>
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import io
+
+import serial
+from serial.tools import miniterm
+
+from platformio.device.monitor.terminal import NonInteractiveConsole, Terminal
+
+
+def test_terminal_does_not_crash_when_stdin_is_not_a_tty(monkeypatch):
+    # Regression test for https://github.com/platformio/platformio-core/issues/5113
+    # `pio device monitor` used to crash with
+    # `termios.error: (25, 'Inappropriate ioctl for device')` whenever stdin
+    # was a pipe rather than a real terminal, because `miniterm.Miniterm`
+    # unconditionally builds a `Console` that calls `termios.tcgetattr` on
+    # stdin during construction.
+    monkeypatch.setattr("sys.stdin", io.StringIO("hello"))
+    monkeypatch.setattr("sys.stdin.isatty", lambda: False, raising=False)
+
+    ser = serial.serial_for_url("loop://", do_not_open=True)
+    ser.open()
+    try:
+        term = Terminal(ser, echo=False, eol="crlf", filters=["default"])
+        assert isinstance(term.console, NonInteractiveConsole)
+    finally:
+        ser.close()
+
+
+def test_terminal_reads_piped_stdin_and_stops_cleanly_on_eof(monkeypatch):
+    monkeypatch.setattr("sys.stdin", io.StringIO("hi"))
+    monkeypatch.setattr("sys.stdin.isatty", lambda: False, raising=False)
+
+    ser = serial.serial_for_url("loop://", do_not_open=True)
+    ser.open()
+    term = None
+    try:
+        term = Terminal(ser, echo=False, eol="crlf", filters=["default"])
+        term.set_rx_encoding("UTF-8")
+        term.set_tx_encoding("UTF-8")
+        term.start()
+        term.join(True)
+        term.join()
+
+        assert term.alive is False
+        assert term.pio_unexpected_exception is None
+    finally:
+        if term is not None:
+            term.console.cleanup()
+        ser.close()
+
+
+def test_terminal_uses_real_console_when_stdin_is_a_tty(monkeypatch):
+    # Non-regression: the fix must not change behavior for the normal,
+    # interactive case. `Console.__init__` itself is stubbed out (rather
+    # than calling the real termios-based one) because stdin under the
+    # test runner is neither a pipe nor a real TTY, so there is no fd for
+    # `termios.tcgetattr` to act on either way — this test only asserts
+    # *which* console class gets selected, not termios behavior itself.
+    monkeypatch.setattr("sys.stdin.isatty", lambda: True, raising=False)
+    monkeypatch.setattr(miniterm.Console, "__init__", lambda self: None)
+    monkeypatch.setattr(miniterm.Console, "cleanup", lambda self: None)
+
+    ser = serial.serial_for_url("loop://", do_not_open=True)
+    ser.open()
+    term = None
+    try:
+        term = Terminal(ser, echo=False, eol="crlf", filters=["default"])
+        assert isinstance(term.console, miniterm.Console)
+        assert not isinstance(term.console, NonInteractiveConsole)
+    finally:
+        if term is not None:
+            term.console.cleanup()
+        ser.close()


### PR DESCRIPTION
### AI disclosure

Written by Claude (Anthropic, Sonnet 5). The entire patch, root-cause analysis, and verification below were produced by an AI agent. I (the human account owner) reviewed the diff and the verification steps before submitting.

### Problem

`pio device monitor` (and `pio run -t monitor`) crashes with `termios.error: (25, 'Inappropriate ioctl for device')` whenever stdin isn't a real TTY, e.g.:

```
$ echo "" | pio run -t monitor
```

### Root cause

`Terminal.__init__` in `platformio/device/monitor/terminal.py` calls `super().__init__()`, which is `miniterm.Miniterm.__init__` (from pyserial). That constructor unconditionally does `self.console = Console()`, and pyserial's POSIX `Console.__init__` immediately calls `termios.tcgetattr(sys.stdin.fileno())` to put the terminal into raw mode. There is no TTY to reconfigure when stdin is a pipe, so this raises before `Terminal.__init__`'s own body (or even `new_terminal()`, its caller) gets a chance to react.

### Fix

Added `NonInteractiveConsole`, a small subclass of pyserial's own `ConsoleBase` (the same base class miniterm itself falls back to on non-POSIX platforms that don't have `termios`). It reads bytes from stdin directly with `sys.stdin.read(1)` — no raw-mode reconfiguration needed, since there's no interactive terminal involved — and reports EOF as the monitor's exit character so the writer thread stops cleanly instead of spinning on empty reads forever.

Because the crash happens *inside* the parent constructor call, `Terminal.__init__` temporarily swaps `miniterm.Console` for a factory that returns `NonInteractiveConsole` before calling `super().__init__()`, only when `sys.stdin.isatty()` is false, restoring it immediately after (via `try/finally`). This is the narrowest fix I found: it changes nothing when stdin is a real terminal (the reported, working case), and the substitution window is a single synchronous constructor call, not global state kept around afterward.

### Testing

I confirmed the crash first, then verified the fix, both against a real `serial.serial_for_url("loop://")` instance (pyserial's built-in loopback transport — no physical hardware needed) with stdin replaced by a pipe:

**Before the fix** (`git stash` on this change): `Terminal(ser, ...)` raises `termios.error: (25, 'Inappropriate ioctl for device')` — the exact error from the issue.

**After the fix**: `Terminal(ser, ...)` succeeds, uses `NonInteractiveConsole`; a full `start()`/`join()` cycle correctly reads piped bytes and stops cleanly on EOF with no exception recorded in `pio_unexpected_exception`.

**Non-regression**: when stdin is a real TTY, `Terminal` still uses pyserial's real `Console` — verified with a dedicated test.

Added `tests/commands/test_device_monitor_terminal.py` (3 tests, all passing) covering: construction doesn't crash when stdin isn't a TTY, the writer loop reads piped data and exits cleanly on EOF, and the TTY path is unchanged. Ran the existing `tests/commands/test_device_monitor.py` alongside it — all pass, no regressions. Also ran `black`, `isort`, and `pylint --rcfile=./.pylintrc` on both changed files — clean (`10.00/10` on pylint).

I don't have physical hardware to test against `pio run -t monitor` end-to-end on a real board; the fix and tests operate at the `Terminal`/`miniterm` layer where the actual bug lives, using pyserial's loopback URL as a stand-in serial device.

Fixes #5113