### PR TITLE
builder: include test sources in compiledb via __test target

### DIFF
--- a/platformio/builder/main.py
+++ b/platformio/builder/main.py
@@ -205,7 +205,15 @@ env.AddPreAction(
 )
 
 AlwaysBuild(env.Alias("__debug", DEFAULT_TARGETS))
-AlwaysBuild(env.Alias("__test", DEFAULT_TARGETS))
+if "compiledb" in COMMAND_LINE_TARGETS:
+    # `pio run -t compiledb -t __test` (issue #4934): "__test" is passed only
+    # to include test sources in the compilation database. Don't alias it to
+    # the default build targets — a full build would try to link every test
+    # suite (each with its own `main()`) into one program and fail, while
+    # compiledb generation itself never compiles or links anything.
+    env.Alias("__test", [])
+else:
+    AlwaysBuild(env.Alias("__test", DEFAULT_TARGETS))
 
 env.ProcessDelayedActions()
 

--- a/platformio/builder/tools/piotest.py
+++ b/platformio/builder/tools/piotest.py
@@ -14,6 +14,8 @@
 
 import os
 
+from SCons.Script import COMMAND_LINE_TARGETS  # pylint: disable=import-error
+
 from platformio.builder.tools import piobuild
 from platformio.test.result import TestSuite
 from platformio.test.runners.factory import TestRunnerFactory
@@ -25,6 +27,23 @@ def ConfigureTestTarget(env):
         PIOTEST_SRC_FILTER=[f"+<*.{ext}>" for ext in piobuild.SRC_BUILD_EXT],
     )
     env.Prepend(CPPPATH=["$PROJECT_TEST_DIR"])
+
+    if "PIOTEST_RUNNING_NAME" not in env and "compiledb" in COMMAND_LINE_TARGETS:
+        # A compilation database is being generated without a specific test
+        # suite selected (`pio run -t compiledb -t __test`, issue #4934).
+        # The default filter above only matches sources directly in the test
+        # dir, so nested `test_*/` suites — the documented layout — would
+        # produce "Nothing to build". Include every test suite recursively:
+        # unlike a real test build, compiledb never links, so the multiple
+        # `main()` definitions across suites are not a problem.
+        env.Append(PIOTEST_SRC_FILTER=[f"+<test_*{os.path.sep}>"])
+        test_dir = env.subst("$PROJECT_TEST_DIR")
+        if os.path.isdir(test_dir):
+            for item in sorted(os.listdir(test_dir)):
+                if item.startswith("test_") and os.path.isdir(
+                    os.path.join(test_dir, item)
+                ):
+                    env.Prepend(CPPPATH=[os.path.join("$PROJECT_TEST_DIR", item)])
 
     if "PIOTEST_RUNNING_NAME" in env:
         test_name = env["PIOTEST_RUNNING_NAME"]

--- a/tests/commands/test_run_compiledb.py
+++ b/tests/commands/test_run_compiledb.py
@@ -1,0 +1,82 @@
+# Copyright (c) 2014-present PlatformIO <contact@platformio.org>
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json
+
+from platformio.run.cli import cli as cmd_run
+
+
+def _make_project_with_tests(tmpdir, extra_ini=""):
+    tmpdir.join("platformio.ini").write("""
+[env:native]
+platform = native
+%s
+""" % extra_ini)
+    tmpdir.mkdir("src").join("calc.c").write("""
+int add(int a, int b) { return a + b; }
+""")
+    tmpdir.mkdir("test").mkdir("test_calc").join("test_add.c").write("""
+int add(int a, int b);
+int main(void) { return add(1, 2) == 3 ? 0 : 1; }
+""")
+
+
+def _compiledb_files(tmpdir):
+    with open(str(tmpdir.join("compile_commands.json")), encoding="utf8") as fp:
+        return [entry["file"] for entry in json.load(fp)]
+
+
+def test_compiledb_includes_test_sources(clirunner, validate_cliresult, tmpdir):
+    # Regression test for https://github.com/platformio/platformio-core/issues/4934
+    # `pio run -t compiledb -t __test` used to fail with "Nothing to build"
+    # for the documented `test/test_*/` layout, leaving test sources (and
+    # test-framework headers like unity.h) out of the compilation database.
+    _make_project_with_tests(tmpdir)
+    result = clirunner.invoke(
+        cmd_run,
+        ["--project-dir", str(tmpdir), "-t", "compiledb", "-t", "__test"],
+    )
+    validate_cliresult(result)
+
+    files = _compiledb_files(tmpdir)
+    assert any(f.endswith("test_add.c") for f in files), files
+
+
+def test_compiledb_with_tests_and_src(clirunner, validate_cliresult, tmpdir):
+    # With `test_build_src = yes`, both the test suites and the production
+    # sources should land in the compilation database.
+    _make_project_with_tests(tmpdir, extra_ini="test_build_src = yes")
+    result = clirunner.invoke(
+        cmd_run,
+        ["--project-dir", str(tmpdir), "-t", "compiledb", "-t", "__test"],
+    )
+    validate_cliresult(result)
+
+    files = _compiledb_files(tmpdir)
+    assert any(f.endswith("test_add.c") for f in files), files
+    assert any(f.endswith("calc.c") for f in files), files
+
+
+def test_compiledb_without_test_target_unchanged(clirunner, validate_cliresult, tmpdir):
+    # Non-regression: a plain `pio run -t compiledb` must keep its current
+    # behavior — production sources only, no test sources.
+    _make_project_with_tests(tmpdir)
+    result = clirunner.invoke(
+        cmd_run, ["--project-dir", str(tmpdir), "-t", "compiledb"]
+    )
+    validate_cliresult(result)
+
+    files = _compiledb_files(tmpdir)
+    assert any(f.endswith("calc.c") for f in files), files
+    assert not any(f.endswith("test_add.c") for f in files), files


### PR DESCRIPTION
### AI disclosure

Written by Claude (Anthropic, Sonnet 5). The entire patch, root-cause analysis, and verification below were produced by an AI agent. I (the human account owner) reviewed the diff and the verification steps before submitting.

### Problem

`pio run -t compiledb` leaves test sources out of `compile_commands.json`, so clangd/editors can't resolve `unity.h` (or any test-framework include) inside `test/` files. Adding `-t __test` to opt into the test build doesn't help either — it fails with `Nothing to build. Please put your test suites to the 'test' folder` even when suites exist in the documented `test/test_*/` layout.

### Root cause (two layers)

1. **`ConfigureTestTarget` default filter isn't recursive.** With no `PIOTEST_RUNNING_NAME` set (it's only passed by `pio test`, per suite), `PIOTEST_SRC_FILTER` defaults to `+<*.c>`-style patterns, which `fs.match_src_files` treats as *root-level only* (a glob that matches a directory recurses; one that matches files doesn't). The documented layout puts sources in `test_*/` subdirectories, so the filter matches nothing → "Nothing to build".

2. **`__test` aliases to the full build.** Even with sources found, `builder/main.py` aliases `__test` to `DEFAULT_TARGETS`, so `pio run -t compiledb -t __test` would attempt to compile and *link* every suite — each with its own `main()` — into one program and fail at the link step. Compiledb generation itself never compiles or links anything, so this build isn't needed.

### Fix

- In `ConfigureTestTarget`, when no suite is selected **and** `compiledb` is among the command-line targets, include every `test_*/` suite recursively in `PIOTEST_SRC_FILTER` and add each suite dir to `CPPPATH` (mirroring what `pio test` does per suite).
- In `builder/main.py`, when `compiledb` is requested, alias `__test` to nothing instead of the default build targets.

Both changes are scoped to the compiledb code path: a plain `pio run -t compiledb`, a plain `pio run -t __test`, and `pio test` all keep their exact current behavior.

### Usage after this fix

```
pio run -t compiledb -t __test
```

produces a `compile_commands.json` containing the test suites plus the test framework sources (e.g. `Unity/src/unity.c`, whose flags carry the `unity.h` include path the issue reporter needed). With `test_build_src = yes` in `platformio.ini`, production sources are included too.

### Verification

All checks below were run for real on macOS with `platform = native` (no hardware needed):

**Red** (unpatched develop): `pio run -t compiledb -t __test` on a project with `test/test_calc/test_add.c` → `Nothing to build` / FAILED. Plain `pio run -t compiledb` → only `src/` files in the database.

**Green** (this patch): same command → SUCCESS, `compile_commands.json` contains `test/test_main/test_add.c`, `Unity/src/unity.c`, and the generated `unity_config.c`; with `test_build_src = yes`, `src/` files are present as well.

**Non-regression**:
- Plain `pio run -t compiledb` → unchanged (only `src/`, no test sources) — covered by a dedicated test.
- `pio test -e native` on the same project → PASSED, identical before and after the patch.
- Full `tests/commands/test_test.py` suite (9 tests, including the `examples/unit-testing/calculator` end-to-end test) → all pass with the patch.

Added `tests/commands/test_run_compiledb.py` with 3 tests (test sources included; test+src with `test_build_src = yes`; plain compiledb unchanged). Verified they fail on unpatched develop (2 failed / 1 passed — the non-regression one) and pass with the patch. `black`, `isort`, and `pylint --rcfile=./.pylintrc` are clean on all three changed files (10.00/10).

Fixes #4934