### PR TITLE
Fix: pio pkg list crashes when its output stream cannot encode the tree characters

### DIFF
--- a/platformio/compat.py
+++ b/platformio/compat.py
@@ -90,6 +90,17 @@ def get_locale_encoding():
     return locale.getpreferredencoding()
 
 
+def stdout_encodes(text):
+    encoding = getattr(sys.stdout, "encoding", None)
+    if not encoding:
+        return False
+    try:
+        text.encode(encoding)
+    except (UnicodeEncodeError, LookupError):
+        return False
+    return True
+
+
 def get_object_members(obj, ignore_private=True):
     members = inspect.getmembers(obj, lambda a: not inspect.isroutine(a))
     if not ignore_private:

--- a/platformio/package/commands/list.py
+++ b/platformio/package/commands/list.py
@@ -18,6 +18,7 @@ from typing import List
 import click
 
 from platformio import fs
+from platformio.compat import stdout_encodes
 from platformio.package.manager.library import LibraryPackageManager
 from platformio.package.manager.platform import PlatformPackageManager
 from platformio.package.manager.tool import ToolPackageManager
@@ -25,6 +26,14 @@ from platformio.package.meta import PackageItem, PackageSpec
 from platformio.platform.exception import UnknownPlatform
 from platformio.platform.factory import PlatformFactory
 from platformio.project.config import ProjectConfig
+
+
+def get_tree_glyphs():
+    """Return (indent, tee, elbow), falling back to ASCII when the output
+    stream cannot encode the box-drawing characters."""
+    if stdout_encodes("│├└─"):
+        return ("│   ", "├──", "└──")
+    return ("|   ", "|--", "`--")
 
 
 @click.command("list", short_help="List installed packages")
@@ -96,11 +105,12 @@ def print_dependency_tree(pm, specs=None, filter_specs=None, level=0, verbose=Fa
         printed_pkgs.append(pkg.path)
         pm.memcache_set("__printed_pkgs", printed_pkgs)
 
+        indent, tee, elbow = get_tree_glyphs()
         click.echo(
             "%s%s %s"
             % (
-                "│   " * level,
-                "├──" if index < len(candidates) - 1 else "└──",
+                indent * level,
+                tee if index < len(candidates) - 1 else elbow,
                 humanize_package(
                     pkg,
                     spec=spec,

--- a/tests/commands/pkg/test_list.py
+++ b/tests/commands/pkg/test_list.py
@@ -14,8 +14,10 @@
 
 # pylint: disable=unused-argument
 
+import io
+
 from platformio.package.commands.install import package_install_cmd
-from platformio.package.commands.list import package_list_cmd
+from platformio.package.commands.list import get_tree_glyphs, package_list_cmd
 
 PROJECT_CONFIG_TPL = """
 [env]
@@ -135,3 +137,20 @@ def test_global_packages(clirunner, validate_cliresult, isolated_pio_core, tmp_p
     validate_cliresult(result)
     assert "DallasTemperature" in result.output
     assert "OneWire" in result.output
+
+
+def test_tree_glyphs(monkeypatch):
+    def with_encoding(encoding):
+        monkeypatch.setattr(
+            "sys.stdout", io.TextIOWrapper(io.BytesIO(), encoding=encoding)
+        )
+        return get_tree_glyphs()
+
+    assert with_encoding("utf-8") == ("│   ", "├──", "└──")
+
+    # a non-Unicode console must not blow up with UnicodeEncodeError
+    for encoding in ("cp1252", "ascii"):
+        glyphs = with_encoding(encoding)
+        assert glyphs == ("|   ", "|--", "`--")
+        for glyph in glyphs:
+            glyph.encode(encoding)


### PR DESCRIPTION
`pio pkg list` draws the dependency tree with the box-drawing characters, which raises `UnicodeEncodeError` when the output stream cannot encode them - redirecting to a file on Windows is the case in the issue, since the console path goes through `WriteConsoleW` but a redirected stream falls back to the locale encoding

as noted in the issue, click does not modify `sys.stdout`, so it does not help here. I confirmed that on a cp1252 stream `click.echo` still raises

rather than dropping the tree characters for everyone, this checks whether the output stream can encode them and falls back to ASCII (`|`, `|--`, `` `-- ``) only when it cannot, so the output is unchanged on a UTF-8 capable terminal. The check lives in `platformio/compat.py` next to `get_locale_encoding` and `is_terminal`

after the change the box-drawing characters are only produced through that guarded helper, so the command has no other way to hit this

one related spot I left alone: `pio pkg show` prints `•`, which fails the same way on cp437/cp866/cp932 (though not on cp1252, so it is a different set of consoles). Happy to fix that too if you want it in here

Resolve #5053
