### PR TITLE
Avoid passing unsupported -g2 and -ggdb2 debug flags to the assembler

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -29,6 +29,7 @@ test-driven methodologies, and modern toolchains for unrivaled success.
 * Increased the maximum length of dependency version specifications to support long package URLs in project manifests (`issue #5459 <https://github.com/platformio/platformio-core/issues/5459>`_)
 * Fixed an issue that could cause an infinite retry loop when a cached package mirror redirect repeatedly failed (`pull #5435 <https://github.com/platformio/platformio-core/pull/5435>`_)
 * Fixed an issue where the library integrity metadata was not invalidated after correcting invalid version requirements (`issue #5232 <https://github.com/platformio/platformio-core/issues/5232>`_)
+* Fixed an issue where |DEBUGGING| builds passed unsupported GCC debugging flags such as ``-g2`` to the ``as`` assembler, causing a fatal "unknown option" error (`issue #5005 <https://github.com/platformio/platformio-core/issues/5005>`_)
 * Fixed an issue where |UNITTESTING| failed on Windows due to improper handling of ``Serial.end()`` (`issue #5359 <https://github.com/platformio/platformio-core/issues/5359>`_)
 * Fixed an issue with floating-point precision in duration formatting that caused incorrect millisecond reporting (`issue #5424 <https://github.com/platformio/platformio-core/issues/5424>`_)
 * Fixed an issue where the test suite status was incorrectly hardcoded as PASSED (`issue #5183 <https://github.com/platformio/platformio-core/issues/5183>`_)

--- a/platformio/builder/tools/piomisc.py
+++ b/platformio/builder/tools/piomisc.py
@@ -116,15 +116,12 @@ def ConfigureDebugTarget(env):
     ]
 
     if optimization_flags:
-        env.AppendUnique(
-            ASFLAGS=[
-                # skip -O flags for assembler
-                f
-                for f in optimization_flags
-                if f.startswith("-g")
-            ],
-            LINKFLAGS=optimization_flags,
-        )
+        env.AppendUnique(LINKFLAGS=optimization_flags)
+
+    if any(f.startswith("-g") for f in optimization_flags):
+        # issue #5005: pass the plain `-g` flag to the assembler which
+        # does not support GCC debugging levels such as `-g2` or `-ggdb2`
+        env.AppendUnique(ASFLAGS=["-g"])
 
 
 def GetExtraScripts(env, scope):

--- a/tests/misc/test_builder.py
+++ b/tests/misc/test_builder.py
@@ -1,0 +1,85 @@
+# Copyright (c) 2014-present PlatformIO <contact@platformio.org>
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from platformio.builder.tools.piomisc import ConfigureDebugTarget
+from platformio.project.options import ProjectOptions
+
+
+class SConsEnvironmentStub(dict):
+    """Reproduces the SCons Environment API used by ConfigureDebugTarget"""
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.custom_project_options = {}
+
+    def Append(self, **kwargs):
+        for key, values in kwargs.items():
+            self.setdefault(key, []).extend(values)
+
+    def AppendUnique(self, **kwargs):
+        for key, values in kwargs.items():
+            container = self.setdefault(key, [])
+            for value in values:
+                if value not in container:
+                    container.append(value)
+
+    def MergeFlags(self, parsed_flags):
+        self.Append(**parsed_flags)
+
+    def ParseFlags(self, raw_flags):
+        ccflags = []
+        for item in raw_flags:
+            ccflags.extend(item.split())
+        return {"CCFLAGS": ccflags}
+
+    def GetProjectOptions(self, as_dict=False):
+        assert as_dict
+        return self.custom_project_options
+
+    def GetProjectOption(self, name, default=None):
+        if name in self.custom_project_options:
+            return self.custom_project_options[name]
+        option = ProjectOptions.get("env.%s" % name)
+        return option.default if option else default
+
+
+def test_configure_debug_target_default_flags():
+    env = SConsEnvironmentStub(
+        ASFLAGS=["-mcpu=cortex-m3", "-mthumb", "-g"],
+        CCFLAGS=["-mcpu=cortex-m3", "-mthumb", "-Os", "-g"],
+        LINKFLAGS=["-mcpu=cortex-m3", "-Os"],
+    )
+    ConfigureDebugTarget(env)
+    # issue #5005: the `as` assembler supports only the plain `-g` flag
+    assert env["ASFLAGS"] == ["-mcpu=cortex-m3", "-mthumb", "-g"]
+    assert env["CCFLAGS"] == ["-mcpu=cortex-m3", "-mthumb", "-Og", "-g2", "-ggdb2"]
+    assert env["LINKFLAGS"] == ["-mcpu=cortex-m3", "-Og", "-g2", "-ggdb2"]
+    assert env["CPPDEFINES"] == ["__PLATFORMIO_BUILD_DEBUG__"]
+
+
+def test_configure_debug_target_custom_flags():
+    env = SConsEnvironmentStub(ASFLAGS=["-mthumb"], CCFLAGS=["-mthumb", "-Os"])
+    env.custom_project_options["debug_build_flags"] = ["-O0 -ggdb3"]
+    ConfigureDebugTarget(env)
+    assert env["ASFLAGS"] == ["-mthumb", "-g"]
+    assert env["CCFLAGS"] == ["-mthumb", "-O0", "-ggdb3"]
+    assert env["LINKFLAGS"] == ["-O0", "-ggdb3"]
+
+
+def test_configure_debug_target_without_debugging_flags():
+    env = SConsEnvironmentStub(ASFLAGS=["-mthumb"], CCFLAGS=["-mthumb", "-Os"])
+    env.custom_project_options["debug_build_flags"] = ["-O0"]
+    ConfigureDebugTarget(env)
+    assert env["ASFLAGS"] == ["-mthumb"]
+    assert env["CCFLAGS"] == ["-mthumb", "-O0"]


### PR DESCRIPTION
## Description

Debug builds forward every `-g*` flag from `debug_build_flags` to `ASFLAGS`, so the default `-Og -g2 -ggdb2` puts `-g2` and `-ggdb2` on the assembler command line. Toolchains that invoke `as` directly then stop with a fatal unknown option error, because `as` only understands the plain `-g` flag, not the GCC debugging levels.

## Changes

`ConfigureDebugTarget` now appends a single `-g` to `ASFLAGS` whenever the debug flags request debug info, instead of copying `-g2`/`-ggdb2` verbatim. `LINKFLAGS` handling stays as it was. Also adds `tests/misc/test_builder.py` covering the default flags, custom `debug_build_flags`, and the case without debugging flags, plus a changelog entry.

## Testing

The new builder tests pass together with `tests/project/test_config.py` (24 passed, 1 skipped, Python 3.11 on Linux). The default-flags and custom-flags tests fail without the fix.

## Related Issue

Fixes #5005