### PR TITLE
Sort project library integrity data

### DIFF
--- a/platformio/package/commands/install.py
+++ b/platformio/package/commands/install.py
@@ -287,7 +287,7 @@ def _uninstall_project_unused_libdeps(lm, lib_deps):
                 pass
     if not storage_dir.is_dir():
         storage_dir.mkdir(parents=True)
-    integrity_dat.write_text("\n".join(lib_deps), encoding="utf-8")
+    integrity_dat.write_text("\n".join(sorted(lib_deps)), encoding="utf-8")
 
 
 def _install_project_private_library_deps(private_pkg, private_lm, env_lm, options):

--- a/tests/commands/pkg/test_install.py
+++ b/tests/commands/pkg/test_install.py
@@ -20,7 +20,10 @@ import pytest
 
 from platformio import fs
 from platformio.dependencies import get_core_dependencies
-from platformio.package.commands.install import package_install_cmd
+from platformio.package.commands.install import (
+    _uninstall_project_unused_libdeps,
+    package_install_cmd,
+)
 from platformio.package.manager.library import LibraryPackageManager
 from platformio.package.manager.platform import PlatformPackageManager
 from platformio.package.manager.tool import ToolPackageManager
@@ -48,6 +51,22 @@ def pkgs_to_specs(pkgs):
         PackageSpec(name=pkg.metadata.name, requirements=pkg.metadata.version)
         for pkg in pkgs
     ]
+
+
+def test_project_libdeps_integrity_is_sorted(tmp_path):
+    storage_dir = tmp_path / "libdeps"
+    lm = LibraryPackageManager(str(storage_dir))
+    lib_deps = [
+        "https://github.com/thomasfredericks/Bounce2"
+        "#d744e0690f5b5d403f2847014fa1b16c72da9970",
+        "solarcaratuva/boost-preprocessor@^1.77.0",
+    ]
+
+    _uninstall_project_unused_libdeps(lm, lib_deps)
+
+    assert (storage_dir / "integrity.dat").read_text(encoding="utf-8") == "\n".join(
+        sorted(lib_deps)
+    )
 
 
 def test_global_packages(


### PR DESCRIPTION
Closes #5491

Serialize the unique project library specifications in sorted order when
writing `integrity.dat`. This keeps identical dependency sets byte-stable across
Python processes without changing dependency resolution, installation order,
set comparison, or unused-package removal.

The focused regression exercises the cleanup helper and asserts the canonical
file contents; it fails against the previous implementation under a hash seed
that produces the opposite set order.

Validation:

- `tests/commands/pkg/test_install.py`: 11 passed
- `tox run -e lint`: 10.00/10 for source and tests
- `git diff --check`

AI assistance: OpenAI Codex helped draft the change and regression test. I
reviewed the complete diff and validation evidence and take responsibility for
the contribution.