### PR TITLE
prevent path traversal via chmod and mtime in zip unpacking

### DIFF
--- a/platformio/package/unpack.py
+++ b/platformio/package/unpack.py
@@ -49,8 +49,13 @@ class BaseArchiver:
     def resolve_path(path):
         return os.path.realpath(os.path.abspath(path))
 
-    def is_bad_path(self, path, base):
-        return not self.resolve_path(os.path.join(base, path)).startswith(base)
+def is_bad_path(self, path, base):
+    base = self.resolve_path(base)
+    target = self.resolve_path(os.path.join(base, path))
+    try:
+        return os.path.commonpath([base, target]) != base
+    except ValueError:
+        return True
 
     def extract_item(self, item, dest_dir):
         self._afo.extract(item, dest_dir)

--- a/platformio/package/unpack.py
+++ b/platformio/package/unpack.py
@@ -45,6 +45,13 @@ class BaseArchiver:
     def is_link(self, item):
         raise NotImplementedError()
 
+    @staticmethod
+    def resolve_path(path):
+        return os.path.realpath(os.path.abspath(path))
+
+    def is_bad_path(self, path, base):
+        return not self.resolve_path(os.path.join(base, path)).startswith(base)
+
     def extract_item(self, item, dest_dir):
         self._afo.extract(item, dest_dir)
         self.after_extract(item, dest_dir)
@@ -69,13 +76,6 @@ class TARArchiver(BaseArchiver):
     @staticmethod
     def is_link(item):  # pylint: disable=arguments-differ
         return item.islnk() or item.issym()
-
-    @staticmethod
-    def resolve_path(path):
-        return os.path.realpath(os.path.abspath(path))
-
-    def is_bad_path(self, path, base):
-        return not self.resolve_path(os.path.join(base, path)).startswith(base)
 
     def is_bad_link(self, item, base):
         return not self.resolve_path(
@@ -128,6 +128,16 @@ class ZIPArchiver(BaseArchiver):
 
     def get_item_filename(self, item):
         return item.filename
+
+    def extract_item(self, item, dest_dir):
+        dest_dir = self.resolve_path(dest_dir)
+        if self.is_bad_path(item.filename, dest_dir):
+            return click.secho(
+                "Blocked insecure item `%s` from ZIP archive" % item.filename,
+                fg="red",
+                err=True,
+            )
+        return super().extract_item(item, dest_dir)
 
     def after_extract(self, item, dest_dir):
         self.preserve_permissions(item, dest_dir)

--- a/platformio/package/unpack.py
+++ b/platformio/package/unpack.py
@@ -49,13 +49,13 @@ class BaseArchiver:
     def resolve_path(path):
         return os.path.realpath(os.path.abspath(path))
 
-def is_bad_path(self, path, base):
-    base = self.resolve_path(base)
-    target = self.resolve_path(os.path.join(base, path))
-    try:
-        return os.path.commonpath([base, target]) != base
-    except ValueError:
-        return True
+    def is_bad_path(self, path, base):
+        base = self.resolve_path(base)
+        target = self.resolve_path(os.path.join(base, path))
+        try:
+            return os.path.commonpath([base, target]) != base
+        except ValueError:
+            return True
 
     def extract_item(self, item, dest_dir):
         self._afo.extract(item, dest_dir)


### PR DESCRIPTION
`ZIPArchiver` applied chmod and mtime to the raw archive entry name joined onto the destination directory, so an entry like `../name` could change permissions (including setuid) on a file outside the extraction directory. the tar path already guards this with `is_bad_path`, the zip path did not

this lifts `is_bad_path`/`resolve_path` to the base archiver and blocks zip entries that resolve outside the destination, matching the existing tar behavior
