### PR TITLE
Fail with a clear error when device monitor stdin is not a TTY

### DIFF
--- a/platformio/device/monitor/terminal.py
+++ b/platformio/device/monitor/terminal.py
@@ -99,6 +99,13 @@ def start_terminal(options):
 
 
 def new_terminal(options):
+    if hasattr(sys.stdin, "isatty") and not sys.stdin.isatty():
+        raise UserSideException(
+            "`pio device monitor` requires an interactive terminal on stdin "
+            "and cannot run with piped or redirected input. If you're "
+            "scripting device I/O, talk to the serial port directly instead "
+            "(e.g., with pyserial) rather than through `pio device monitor`."
+        )
     term = Terminal(
         new_serial_instance(options),
         echo=options["echo"],

--- a/platformio/device/monitor/terminal.py
+++ b/platformio/device/monitor/terminal.py
@@ -99,7 +99,7 @@ def start_terminal(options):
 
 
 def new_terminal(options):
-    if hasattr(sys.stdin, "isatty") and not sys.stdin.isatty():
+    if not (hasattr(sys.stdin, "isatty") and sys.stdin.isatty()):
         raise UserSideException(
             "`pio device monitor` requires an interactive terminal on stdin "
             "and cannot run with piped or redirected input. If you're "

--- a/tests/commands/test_device_monitor.py
+++ b/tests/commands/test_device_monitor.py
@@ -13,10 +13,16 @@
 # limitations under the License.
 
 import os
+import sys
+from unittest.mock import MagicMock
+
+import pytest
 
 from platformio import fs
 from platformio.device.finder import SerialPortFinder
 from platformio.device.monitor.command import device_monitor_cmd
+from platformio.device.monitor.terminal import new_terminal
+from platformio.exception import UserSideException
 
 
 def _patch_monitor_internals(monkeypatch, on_register_filters):
@@ -97,3 +103,17 @@ def test_absolute_project_dir_passthrough(
     validate_cliresult(result)
 
     assert captured["project_dir"] == os.path.realpath(str(tmpdir))
+
+
+def test_new_terminal_rejects_non_tty_stdin(monkeypatch):
+    # Regression test for https://github.com/platformio/platformio-core/issues/5113
+    # `pio device monitor` used to crash with a raw termios traceback
+    # ("Inappropriate ioctl for device") whenever stdin was piped instead of
+    # a real terminal, e.g. `echo "" | pio device monitor`. It should fail
+    # with a clear, actionable error instead.
+    fake_stdin = MagicMock()
+    fake_stdin.isatty.return_value = False
+    monkeypatch.setattr(sys, "stdin", fake_stdin)
+
+    with pytest.raises(UserSideException, match="interactive terminal"):
+        new_terminal({})


### PR DESCRIPTION
## Summary

`pio device monitor` crashes with a raw termios traceback (`Inappropriate ioctl for device`) whenever stdin is piped or redirected instead of a real terminal, e.g. `echo "" | pio device monitor`. This happens because pyserial's `Miniterm.Console` calls `termios.tcgetattr()` on stdin during `Terminal` construction, which only works when stdin is an actual TTY.

This PR detects non-TTY stdin before constructing the `Terminal` and raises a clear `UserSideException` instead, pointing users toward talking to the serial port directly (e.g. with pyserial) if they're trying to automate device I/O from a script, which was the reporter's use case.

Fixes #5113

## Changes

- `platformio/device/monitor/terminal.py`: check `sys.stdin.isatty()` at the top of `new_terminal()` before any serial/terminal setup happens
- `tests/commands/test_device_monitor.py`: regression test that mocks a non-TTY stdin and asserts the clear error is raised

## Test plan

- [x] `pytest tests/commands/test_device_monitor.py -v` — all 4 tests pass (3 existing + 1 new)
- [x] `make lint` (pylint) — 10.00/10 on both changed files
- [x] `black --check` / `isort --check-only` — clean, no changes needed
- [x] `codespell` — clean