### PR TITLE
Update marshmallow constraints (allow 3.x and 4.x)

### DIFF
--- a/platformio/dependencies.py
+++ b/platformio/dependencies.py
@@ -31,7 +31,7 @@ def get_pip_dependencies():
         "bottle == 0.13.*",
         "click >=8.0.4, <8.6, !=8.3",  # click 9.0 removes 'protected_args' attribute
         "colorama",
-        "marshmallow == 3.*",
+        "marshmallow >=3, <5",
         "pyelftools >=0.27, <1",
         "pyserial == 3.5.*",  # keep in sync "device/monitor/terminal.py"
         "requests%s == 2.*" % ("[socks]" if is_proxy_set(socks=True) else ""),

--- a/platformio/package/manifest/schema.py
+++ b/platformio/package/manifest/schema.py
@@ -231,8 +231,11 @@ class ManifestSchema(BaseSchema):
         )
     )
 
+    # Marshmallow 4 passes a `data_key` kwarg to field validators, Marshmallow 3
+    # does not. `**_` keeps these validators compatible with both.
+
     @validates("version")
-    def validate_version(self, value):
+    def validate_version(self, value, **_):
         try:
             value = str(value)
             assert "." in value
@@ -249,7 +252,7 @@ class ManifestSchema(BaseSchema):
             ) from exc
 
     @validates("license")
-    def validate_license(self, value):
+    def validate_license(self, value, **_):
         try:
             spdx = self.load_spdx_licenses()
         except requests.exceptions.RequestException as exc:


### PR DESCRIPTION
Marshmallow 3.x is not being packaged anymore in latest Fedora/Arch/others.
This has caused the Fedora `python-platformio` package to become broken / orphaned.

Update constraints to allow Marshmallow 3.x and 4.x.

https://marshmallow.readthedocs.io/en/stable/upgrading.html#upgrading-to-4-0